### PR TITLE
feat: add Yahtzee and Blackjack games

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# CLI Play
+
+A collection of classic terminal games built with Go and the
+[Charm](https://charm.sh/) ecosystem. Features an animated digital rain
+splash screen and a game selection menu.
+
+## Games
+
+| Game | Status |
+|------|--------|
+| Yahtzee | Playable |
+| Blackjack | Playable |
+| Wordle | Coming soon |
+| Minesweeper | Coming soon |
+| Sudoku | Coming soon |
+| 2048 | Coming soon |
+
+## Install
+
+```bash
+go install github.com/herbhall/cli-play/cmd/cli-play@latest
+```
+
+## Usage
+
+```bash
+cli-play
+```
+
+Or run from source:
+
+```bash
+go run ./cmd/cli-play
+```
+
+## Build
+
+```bash
+go build -o cli-play ./cmd/cli-play
+```
+
+## Requirements
+
+- Go 1.23+
+- A terminal with 256-color support (most modern terminals)
+
+## Credits
+
+Built by [Herb Hall](https://github.com/herbhall) and
+[Claude Code](https://claude.ai/claude-code) using the
+[Charm](https://charm.sh/) ecosystem
+([Bubble Tea](https://github.com/charmbracelet/bubbletea),
+[Lip Gloss](https://github.com/charmbracelet/lipgloss)).

--- a/internal/blackjack/game.go
+++ b/internal/blackjack/game.go
@@ -1,0 +1,420 @@
+package blackjack
+
+import (
+	"errors"
+	"fmt"
+	"math/rand/v2"
+)
+
+// Suit represents a card suit.
+type Suit int
+
+const (
+	Spades Suit = iota
+	Hearts
+	Diamonds
+	Clubs
+)
+
+// Symbol returns the Unicode symbol for the suit.
+func (s Suit) Symbol() string {
+	switch s {
+	case Spades:
+		return "\u2660"
+	case Hearts:
+		return "\u2665"
+	case Diamonds:
+		return "\u2666"
+	case Clubs:
+		return "\u2663"
+	}
+	return "?"
+}
+
+// Rank represents a card rank from Ace to King.
+type Rank int
+
+const (
+	Ace Rank = iota + 1
+	Two
+	Three
+	Four
+	Five
+	Six
+	Seven
+	Eight
+	Nine
+	Ten
+	Jack
+	Queen
+	King
+)
+
+// String returns the display string for a rank.
+func (r Rank) String() string {
+	switch r {
+	case Ace:
+		return "A"
+	case Jack:
+		return "J"
+	case Queen:
+		return "Q"
+	case King:
+		return "K"
+	default:
+		return fmt.Sprintf("%d", int(r))
+	}
+}
+
+// Card is a playing card with a rank and suit.
+type Card struct {
+	Rank Rank
+	Suit Suit
+}
+
+// Value returns the blackjack point value of the card.
+// Ace returns 11 (caller must handle soft reduction).
+// Face cards (J, Q, K) return 10.
+func (c Card) Value() int {
+	switch {
+	case c.Rank == Ace:
+		return 11
+	case c.Rank >= Jack:
+		return 10
+	default:
+		return int(c.Rank)
+	}
+}
+
+// String returns a display string like "A♠" or "10♥".
+func (c Card) String() string {
+	return c.Rank.String() + c.Suit.Symbol()
+}
+
+// ShuffleFunc is a function that shuffles a slice of cards in place.
+type ShuffleFunc func([]Card)
+
+// Deck holds a shuffled collection of 52 cards.
+type Deck struct {
+	cards   []Card
+	pos     int
+	shuffle ShuffleFunc
+}
+
+// NewDeck creates a standard 52-card deck and shuffles it.
+// If shuffle is nil, a default Fisher-Yates shuffle using math/rand/v2 is used.
+func NewDeck(shuffle ShuffleFunc) *Deck {
+	cards := make([]Card, 0, 52)
+	for s := Spades; s <= Clubs; s++ {
+		for r := Ace; r <= King; r++ {
+			cards = append(cards, Card{Rank: r, Suit: s})
+		}
+	}
+
+	d := &Deck{cards: cards, shuffle: shuffle}
+	d.shuffleDeck()
+	return d
+}
+
+func (d *Deck) shuffleDeck() {
+	if d.shuffle != nil {
+		d.shuffle(d.cards)
+	} else {
+		rand.Shuffle(len(d.cards), func(i, j int) {
+			d.cards[i], d.cards[j] = d.cards[j], d.cards[i]
+		})
+	}
+	d.pos = 0
+}
+
+// Draw returns the next card from the deck. If the deck is exhausted,
+// it reshuffles automatically before drawing.
+func (d *Deck) Draw() Card {
+	if d.pos >= len(d.cards) {
+		d.shuffleDeck()
+	}
+	c := d.cards[d.pos]
+	d.pos++
+	return c
+}
+
+// Remaining returns how many undrawn cards remain.
+func (d *Deck) Remaining() int {
+	return len(d.cards) - d.pos
+}
+
+// Hand represents a collection of cards held by a player or dealer.
+type Hand struct {
+	Cards []Card
+}
+
+// Add appends a card to the hand.
+func (h *Hand) Add(c Card) {
+	h.Cards = append(h.Cards, c)
+}
+
+// Score returns the best blackjack score for the hand (<=21 if possible).
+// Aces are reduced from 11 to 1 as needed to avoid busting.
+func (h *Hand) Score() int {
+	total := 0
+	aces := 0
+	for _, c := range h.Cards {
+		total += c.Value()
+		if c.Rank == Ace {
+			aces++
+		}
+	}
+	for total > 21 && aces > 0 {
+		total -= 10
+		aces--
+	}
+	return total
+}
+
+// IsSoft returns true if the hand contains an ace currently counted as 11.
+func (h *Hand) IsSoft() bool {
+	total := 0
+	aces := 0
+	for _, c := range h.Cards {
+		total += c.Value()
+		if c.Rank == Ace {
+			aces++
+		}
+	}
+	reduced := 0
+	for total > 21 && reduced < aces {
+		total -= 10
+		reduced++
+	}
+	return reduced < aces
+}
+
+// IsBusted returns true if the hand's score exceeds 21.
+func (h *Hand) IsBusted() bool {
+	return h.Score() > 21
+}
+
+// IsBlackjack returns true if the hand is a natural blackjack (exactly 2 cards totaling 21).
+func (h *Hand) IsBlackjack() bool {
+	return len(h.Cards) == 2 && h.Score() == 21
+}
+
+// Phase represents the current phase of a blackjack round.
+type Phase int
+
+const (
+	PhaseBetting    Phase = iota
+	PhasePlayerTurn Phase = iota
+	PhaseDealerTurn Phase = iota
+	PhaseResult     Phase = iota
+)
+
+// Outcome represents the result of a completed round.
+type Outcome int
+
+const (
+	OutcomeNone            Outcome = iota
+	OutcomePlayerWin       Outcome = iota
+	OutcomeDealerWin       Outcome = iota
+	OutcomePlayerBlackjack Outcome = iota
+	OutcomePush            Outcome = iota
+)
+
+// Stats tracks cumulative win/loss/push counts.
+type Stats struct {
+	Wins   int
+	Losses int
+	Pushes int
+}
+
+// Game holds the complete state of a blackjack game across rounds.
+type Game struct {
+	Deck         *Deck
+	PlayerHand   Hand
+	DealerHand   Hand
+	Phase        Phase
+	Outcome      Outcome
+	Stats        Stats
+	Bet          int
+	Balance      int
+	HoleRevealed bool
+	Message      string
+}
+
+// NewGame creates a new blackjack game with the given starting balance.
+func NewGame(balance int, shuffle ShuffleFunc) *Game {
+	return &Game{
+		Deck:    NewDeck(shuffle),
+		Balance: balance,
+		Phase:   PhaseBetting,
+	}
+}
+
+// NewRound resets the hands and phase for a new round.
+func (g *Game) NewRound() {
+	g.PlayerHand = Hand{}
+	g.DealerHand = Hand{}
+	g.Phase = PhaseBetting
+	g.Outcome = OutcomeNone
+	g.Bet = 0
+	g.HoleRevealed = false
+	g.Message = ""
+}
+
+// PlaceBet validates the bet amount, deducts it from balance, deals cards,
+// and checks for immediate blackjacks.
+func (g *Game) PlaceBet(amount int) error {
+	if amount <= 0 {
+		return errors.New("bet must be positive")
+	}
+	if amount > g.Balance {
+		return errors.New("insufficient balance")
+	}
+
+	g.Bet = amount
+	g.Balance -= amount
+
+	// Deal: player, dealer, player, dealer.
+	g.PlayerHand.Add(g.Deck.Draw())
+	g.DealerHand.Add(g.Deck.Draw())
+	g.PlayerHand.Add(g.Deck.Draw())
+	g.DealerHand.Add(g.Deck.Draw())
+
+	playerBJ := g.PlayerHand.IsBlackjack()
+	dealerBJ := g.DealerHand.IsBlackjack()
+
+	switch {
+	case playerBJ && dealerBJ:
+		g.HoleRevealed = true
+		g.Phase = PhaseResult
+		g.Outcome = OutcomePush
+		g.Balance += g.Bet
+		g.Stats.Pushes++
+		g.Message = "Both have Blackjack! Push."
+	case playerBJ:
+		g.HoleRevealed = true
+		g.Phase = PhaseResult
+		g.Outcome = OutcomePlayerBlackjack
+		payout := g.Bet + g.Bet*3/2
+		g.Balance += payout
+		g.Stats.Wins++
+		g.Message = fmt.Sprintf("BLACKJACK! +$%d", g.Bet*3/2)
+	case dealerBJ:
+		g.HoleRevealed = true
+		g.Phase = PhaseResult
+		g.Outcome = OutcomeDealerWin
+		g.Stats.Losses++
+		g.Message = "Dealer has Blackjack!"
+	default:
+		g.Phase = PhasePlayerTurn
+	}
+
+	return nil
+}
+
+// Hit draws a card for the player. If the player busts, the round ends.
+func (g *Game) Hit() {
+	if g.Phase != PhasePlayerTurn {
+		return
+	}
+
+	g.PlayerHand.Add(g.Deck.Draw())
+
+	if g.PlayerHand.IsBusted() {
+		g.Phase = PhaseResult
+		g.Outcome = OutcomeDealerWin
+		g.HoleRevealed = true
+		g.Stats.Losses++
+		g.Message = fmt.Sprintf("BUST! -%d", g.Bet)
+	}
+}
+
+// Stand ends the player's turn and triggers the dealer's play and resolution.
+func (g *Game) Stand() {
+	if g.Phase != PhasePlayerTurn {
+		return
+	}
+	g.Phase = PhaseDealerTurn
+	g.HoleRevealed = true
+	g.PlayDealer()
+	g.Resolve()
+}
+
+// CanDoubleDown returns true if double down is allowed:
+// exactly 2 cards and sufficient balance to double the bet.
+func (g *Game) CanDoubleDown() bool {
+	return g.Phase == PhasePlayerTurn &&
+		len(g.PlayerHand.Cards) == 2 &&
+		g.Balance >= g.Bet
+}
+
+// DoubleDown doubles the bet, draws exactly one card, and resolves.
+func (g *Game) DoubleDown() error {
+	if g.Phase != PhasePlayerTurn {
+		return errors.New("not player's turn")
+	}
+	if len(g.PlayerHand.Cards) != 2 {
+		return errors.New("can only double down on initial two cards")
+	}
+	if g.Balance < g.Bet {
+		return errors.New("insufficient balance to double down")
+	}
+
+	g.Balance -= g.Bet
+	g.Bet *= 2
+	g.PlayerHand.Add(g.Deck.Draw())
+
+	if g.PlayerHand.IsBusted() {
+		g.Phase = PhaseResult
+		g.Outcome = OutcomeDealerWin
+		g.HoleRevealed = true
+		g.Stats.Losses++
+		g.Message = fmt.Sprintf("BUST! -%d", g.Bet)
+		return nil
+	}
+
+	g.Phase = PhaseDealerTurn
+	g.HoleRevealed = true
+	g.PlayDealer()
+	g.Resolve()
+	return nil
+}
+
+// PlayDealer draws cards for the dealer until the score is 17 or higher.
+func (g *Game) PlayDealer() {
+	for g.DealerHand.Score() < 17 {
+		g.DealerHand.Add(g.Deck.Draw())
+	}
+}
+
+// Resolve compares hands, determines the outcome, updates stats and balance,
+// and sets the result message.
+func (g *Game) Resolve() {
+	g.Phase = PhaseResult
+	g.HoleRevealed = true
+
+	playerScore := g.PlayerHand.Score()
+	dealerScore := g.DealerHand.Score()
+
+	switch {
+	case g.DealerHand.IsBusted():
+		g.Outcome = OutcomePlayerWin
+		g.Balance += g.Bet * 2
+		g.Stats.Wins++
+		g.Message = fmt.Sprintf("Dealer busts! +$%d", g.Bet)
+	case playerScore > dealerScore:
+		g.Outcome = OutcomePlayerWin
+		g.Balance += g.Bet * 2
+		g.Stats.Wins++
+		g.Message = fmt.Sprintf("You win! +$%d", g.Bet)
+	case playerScore < dealerScore:
+		g.Outcome = OutcomeDealerWin
+		g.Stats.Losses++
+		g.Message = fmt.Sprintf("Dealer wins. -$%d", g.Bet)
+	default:
+		g.Outcome = OutcomePush
+		g.Balance += g.Bet
+		g.Stats.Pushes++
+		g.Message = "Push!"
+	}
+}

--- a/internal/blackjack/game_test.go
+++ b/internal/blackjack/game_test.go
@@ -1,0 +1,420 @@
+package blackjack
+
+import "testing"
+
+// fixedDeck returns a ShuffleFunc that places the given cards at the front
+// of the deck, leaving remaining positions untouched. This provides
+// deterministic draws for testing.
+func fixedDeck(cards ...Card) ShuffleFunc {
+	return func(deck []Card) {
+		copy(deck, cards)
+	}
+}
+
+// card is a shorthand constructor for tests.
+func card(r Rank, s Suit) Card {
+	return Card{Rank: r, Suit: s}
+}
+
+func TestHandScore(t *testing.T) {
+	tests := []struct {
+		name  string
+		cards []Card
+		want  int
+	}{
+		{"5+7=12", []Card{card(Five, Spades), card(Seven, Hearts)}, 12},
+		{"K+Q=20", []Card{card(King, Spades), card(Queen, Hearts)}, 20},
+		{"A+9=20", []Card{card(Ace, Spades), card(Nine, Hearts)}, 20},
+		{"A+9+5=15", []Card{card(Ace, Spades), card(Nine, Hearts), card(Five, Diamonds)}, 15},
+		{"A+A=12", []Card{card(Ace, Spades), card(Ace, Hearts)}, 12},
+		{"A+A+9=21", []Card{card(Ace, Spades), card(Ace, Hearts), card(Nine, Diamonds)}, 21},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := Hand{Cards: tt.cards}
+			if got := h.Score(); got != tt.want {
+				t.Errorf("Score() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBlackjack(t *testing.T) {
+	tests := []struct {
+		name  string
+		cards []Card
+		want  bool
+	}{
+		{"A+K is blackjack", []Card{card(Ace, Spades), card(King, Hearts)}, true},
+		{"7+7+7 is not blackjack", []Card{card(Seven, Spades), card(Seven, Hearts), card(Seven, Diamonds)}, false},
+		{"10+Q is not blackjack", []Card{card(Ten, Spades), card(Queen, Hearts)}, false},
+		{"A+5 is not blackjack", []Card{card(Ace, Spades), card(Five, Hearts)}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := Hand{Cards: tt.cards}
+			if got := h.IsBlackjack(); got != tt.want {
+				t.Errorf("IsBlackjack() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBust(t *testing.T) {
+	tests := []struct {
+		name  string
+		cards []Card
+		want  bool
+	}{
+		{"K+Q+5 busts", []Card{card(King, Spades), card(Queen, Hearts), card(Five, Diamonds)}, true},
+		{"A+K+Q=21 no bust", []Card{card(Ace, Spades), card(King, Hearts), card(Queen, Diamonds)}, false},
+		{"9+9+4 busts", []Card{card(Nine, Spades), card(Nine, Hearts), card(Four, Diamonds)}, true},
+		{"10+10 no bust", []Card{card(Ten, Spades), card(Ten, Hearts)}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := Hand{Cards: tt.cards}
+			if got := h.IsBusted(); got != tt.want {
+				t.Errorf("IsBusted() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSoftHand(t *testing.T) {
+	tests := []struct {
+		name  string
+		cards []Card
+		want  bool
+	}{
+		{"A+6 is soft", []Card{card(Ace, Spades), card(Six, Hearts)}, true},
+		{"A+6+K is hard", []Card{card(Ace, Spades), card(Six, Hearts), card(King, Diamonds)}, false},
+		{"K+Q is hard", []Card{card(King, Spades), card(Queen, Hearts)}, false},
+		{"A+A is soft", []Card{card(Ace, Spades), card(Ace, Hearts)}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := Hand{Cards: tt.cards}
+			if got := h.IsSoft(); got != tt.want {
+				t.Errorf("IsSoft() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDealerPlay(t *testing.T) {
+	tests := []struct {
+		name     string
+		cards    []Card
+		wantMin  int
+		wantBust bool
+	}{
+		{
+			"hits on 16 stands on 17+",
+			// Dealer starts with 6+10=16, draws 2 -> 18.
+			[]Card{card(Six, Spades), card(Ten, Hearts), card(Two, Diamonds)},
+			17,
+			false,
+		},
+		{
+			"stands on 17",
+			[]Card{card(Seven, Spades), card(Ten, Hearts)},
+			17,
+			false,
+		},
+		{
+			"dealer busts",
+			// 6+10=16, draws 10 -> 26.
+			[]Card{card(Six, Spades), card(Ten, Hearts), card(Ten, Diamonds)},
+			0,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Game{
+				Deck:       NewDeck(fixedDeck(tt.cards...)),
+				DealerHand: Hand{},
+			}
+			// Deal from the fixed deck.
+			for _, c := range tt.cards[:2] {
+				g.DealerHand.Add(c)
+			}
+			// Remaining cards in deck start at position 0; advance past dealt cards.
+			g.Deck.pos = 2
+
+			g.PlayDealer()
+
+			score := g.DealerHand.Score()
+			if tt.wantBust {
+				if !g.DealerHand.IsBusted() {
+					t.Errorf("expected dealer to bust, got score %d", score)
+				}
+			} else {
+				if score < tt.wantMin {
+					t.Errorf("dealer score %d < minimum %d", score, tt.wantMin)
+				}
+				if g.DealerHand.IsBusted() {
+					t.Errorf("dealer unexpectedly busted with score %d", score)
+				}
+			}
+		})
+	}
+}
+
+func TestOutcomes(t *testing.T) {
+	tests := []struct {
+		name string
+		// Fixed deck order: player1, dealer1, player2, dealer2, then dealer draw cards.
+		deckCards []Card
+		action    string // "stand" or "hit"
+		want      Outcome
+	}{
+		{
+			"player 20 vs dealer 18",
+			// P: 10+10=20, D: 8+10=18.
+			[]Card{card(Ten, Spades), card(Eight, Hearts), card(Ten, Diamonds), card(Ten, Clubs)},
+			"stand",
+			OutcomePlayerWin,
+		},
+		{
+			"player bust",
+			// P: 10+6=16, D: 10+7=17. Player hits 10 -> bust.
+			[]Card{card(Ten, Spades), card(Ten, Hearts), card(Six, Diamonds), card(Seven, Clubs), card(Ten, Clubs)},
+			"hit",
+			OutcomeDealerWin,
+		},
+		{
+			"player blackjack vs dealer 21",
+			// P: A+K=BJ, D: 7+4=11, then dealer draws...
+			// Dealer will draw: 10 -> 21.
+			[]Card{card(Ace, Spades), card(Seven, Hearts), card(King, Diamonds), card(Four, Clubs), card(Ten, Clubs)},
+			"stand", // won't be reached; BJ resolves immediately
+			OutcomePlayerBlackjack,
+		},
+		{
+			"push at 20",
+			// P: 10+10=20, D: 10+10=20.
+			[]Card{card(Ten, Spades), card(Ten, Hearts), card(Ten, Diamonds), card(Ten, Clubs)},
+			"stand",
+			OutcomePush,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGame(1000, fixedDeck(tt.deckCards...))
+			err := g.PlaceBet(50)
+			if err != nil {
+				t.Fatalf("PlaceBet: %v", err)
+			}
+
+			if g.Phase == PhaseResult {
+				// Blackjack was resolved immediately.
+				if g.Outcome != tt.want {
+					t.Errorf("Outcome = %d, want %d", g.Outcome, tt.want)
+				}
+				return
+			}
+
+			switch tt.action {
+			case "hit":
+				g.Hit()
+			case "stand":
+				g.Stand()
+			}
+
+			if g.Outcome != tt.want {
+				t.Errorf("Outcome = %d, want %d", g.Outcome, tt.want)
+			}
+		})
+	}
+}
+
+func TestPayout(t *testing.T) {
+	tests := []struct {
+		name        string
+		deckCards   []Card
+		bet         int
+		wantBalance int
+	}{
+		{
+			"win 1:1",
+			// P: 10+10=20, D: 8+9=17.
+			[]Card{card(Ten, Spades), card(Eight, Hearts), card(Ten, Diamonds), card(Nine, Clubs)},
+			50,
+			1050,
+		},
+		{
+			"blackjack 3:2",
+			// P: A+K=BJ, D: 7+4=11.
+			[]Card{card(Ace, Spades), card(Seven, Hearts), card(King, Diamonds), card(Four, Clubs)},
+			100,
+			1150, // 1000 - 100 + 100 + 150
+		},
+		{
+			"push returns bet",
+			// P: 10+10=20, D: 10+10=20.
+			[]Card{card(Ten, Spades), card(Ten, Hearts), card(Ten, Diamonds), card(Ten, Clubs)},
+			50,
+			1000,
+		},
+		{
+			"loss deducts bet",
+			// P: 10+6=16, D: 10+8=18. Player stands, loses.
+			[]Card{card(Ten, Spades), card(Ten, Hearts), card(Six, Diamonds), card(Eight, Clubs)},
+			50,
+			950,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGame(1000, fixedDeck(tt.deckCards...))
+			err := g.PlaceBet(tt.bet)
+			if err != nil {
+				t.Fatalf("PlaceBet: %v", err)
+			}
+
+			// If not already resolved (blackjack), stand.
+			if g.Phase == PhasePlayerTurn {
+				g.Stand()
+			}
+
+			if g.Balance != tt.wantBalance {
+				t.Errorf("Balance = %d, want %d", g.Balance, tt.wantBalance)
+			}
+		})
+	}
+}
+
+func TestDoubleDown(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func() *Game
+		wantErr bool
+		desc    string
+	}{
+		{
+			"allowed with 2 cards and sufficient balance",
+			func() *Game {
+				// P: 5+6=11, D: 7+8=15. Double draw: 10 -> 21.
+				g := NewGame(1000, fixedDeck(
+					card(Five, Spades), card(Seven, Hearts),
+					card(Six, Diamonds), card(Eight, Clubs),
+					card(Ten, Spades), // double down draw
+					card(Ten, Hearts), // dealer draw
+				))
+				g.PlaceBet(50) //nolint:errcheck
+				return g
+			},
+			false,
+			"should succeed",
+		},
+		{
+			"not allowed with 3 cards",
+			func() *Game {
+				// P: 5+3=8, D: 7+8=15. Hit 2 -> 10. Then try double.
+				g := NewGame(1000, fixedDeck(
+					card(Five, Spades), card(Seven, Hearts),
+					card(Three, Diamonds), card(Eight, Clubs),
+					card(Two, Spades), // hit draw
+				))
+				g.PlaceBet(50) //nolint:errcheck
+				g.Hit()
+				return g
+			},
+			true,
+			"should fail after hit",
+		},
+		{
+			"not allowed with insufficient balance",
+			func() *Game {
+				// Balance 80, bet 50 -> remaining 30, can't double to 100.
+				g := NewGame(80, fixedDeck(
+					card(Five, Spades), card(Seven, Hearts),
+					card(Six, Diamonds), card(Eight, Clubs),
+				))
+				g.PlaceBet(50) //nolint:errcheck
+				return g
+			},
+			true,
+			"should fail with low balance",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := tt.setup()
+			err := g.DoubleDown()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DoubleDown() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCardString(t *testing.T) {
+	tests := []struct {
+		card Card
+		want string
+	}{
+		{card(Ace, Spades), "A\u2660"},
+		{card(Ten, Hearts), "10\u2665"},
+		{card(King, Diamonds), "K\u2666"},
+		{card(Two, Clubs), "2\u2663"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.card.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeckRemainingAndReshuffle(t *testing.T) {
+	d := NewDeck(nil)
+	if d.Remaining() != 52 {
+		t.Errorf("new deck Remaining() = %d, want 52", d.Remaining())
+	}
+
+	for range 52 {
+		d.Draw()
+	}
+
+	if d.Remaining() != 0 {
+		t.Errorf("after 52 draws Remaining() = %d, want 0", d.Remaining())
+	}
+
+	// Drawing from exhausted deck should auto-reshuffle.
+	c := d.Draw()
+	if c.Rank < Ace || c.Rank > King {
+		t.Errorf("unexpected card after reshuffle: %v", c)
+	}
+	if d.Remaining() != 51 {
+		t.Errorf("after reshuffle draw Remaining() = %d, want 51", d.Remaining())
+	}
+}
+
+func TestPlaceBetValidation(t *testing.T) {
+	g := NewGame(100, nil)
+
+	if err := g.PlaceBet(0); err == nil {
+		t.Error("PlaceBet(0) should fail")
+	}
+
+	if err := g.PlaceBet(-10); err == nil {
+		t.Error("PlaceBet(-10) should fail")
+	}
+
+	if err := g.PlaceBet(200); err == nil {
+		t.Error("PlaceBet(200) should fail with balance 100")
+	}
+}

--- a/internal/blackjack/model.go
+++ b/internal/blackjack/model.go
@@ -1,0 +1,261 @@
+package blackjack
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Styles for the blackjack UI.
+var (
+	titleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FFD700"))
+
+	cardWhiteStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("15"))
+
+	cardRedStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FF4444"))
+
+	winStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#00E632"))
+
+	lossStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FF4444"))
+
+	pushStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#FFD700"))
+
+	labelStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("242"))
+
+	helpStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240"))
+
+	holeCardText = "[??]"
+)
+
+// Model is the Bubbletea model for the blackjack game screen.
+type Model struct {
+	game   *Game
+	width  int
+	height int
+	done   bool
+}
+
+// New creates a blackjack model with a starting balance of 1000.
+func New() Model {
+	return Model{game: NewGame(1000, nil)}
+}
+
+// Init returns nil; no initial command needed.
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles input and window size messages.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		key := msg.String()
+
+		if key == "ctrl+c" {
+			return m, tea.Quit
+		}
+
+		switch m.game.Phase {
+		case PhaseBetting:
+			return m.updateBetting(key)
+		case PhasePlayerTurn:
+			return m.updatePlayerTurn(key)
+		case PhaseResult:
+			return m.updateResult(key)
+		}
+	}
+
+	return m, nil
+}
+
+func (m Model) updateBetting(key string) (tea.Model, tea.Cmd) {
+	switch key {
+	case "1":
+		m.game.PlaceBet(10) //nolint:errcheck // UI constrains valid input
+	case "2":
+		m.game.PlaceBet(25) //nolint:errcheck // UI constrains valid input
+	case "3":
+		m.game.PlaceBet(50) //nolint:errcheck // UI constrains valid input
+	case "4":
+		m.game.PlaceBet(100) //nolint:errcheck // UI constrains valid input
+	case "q":
+		m.done = true
+	}
+	return m, nil
+}
+
+func (m Model) updatePlayerTurn(key string) (tea.Model, tea.Cmd) {
+	switch key {
+	case "h":
+		m.game.Hit()
+	case "s":
+		m.game.Stand()
+	case "d":
+		if m.game.CanDoubleDown() {
+			m.game.DoubleDown() //nolint:errcheck // CanDoubleDown pre-validates
+		}
+	}
+	return m, nil
+}
+
+func (m Model) updateResult(key string) (tea.Model, tea.Cmd) {
+	switch key {
+	case "enter", "n":
+		m.game.NewRound()
+	case "q":
+		m.done = true
+	}
+	return m, nil
+}
+
+// View renders the blackjack table.
+func (m Model) View() string {
+	var b strings.Builder
+
+	b.WriteString(titleStyle.Render("--- BLACKJACK ---"))
+	b.WriteString("\n\n")
+
+	b.WriteString(m.renderDealerHand())
+	b.WriteString("\n\n")
+	b.WriteString(m.renderPlayerHand())
+	b.WriteString("\n\n")
+	b.WriteString(m.renderStats())
+	b.WriteString("\n")
+
+	if m.game.Phase == PhaseResult && m.game.Message != "" {
+		b.WriteString("\n")
+		b.WriteString(m.renderMessage())
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(m.renderHelp())
+
+	content := lipgloss.NewStyle().
+		Align(lipgloss.Center).
+		Render(b.String())
+
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+}
+
+func (m Model) renderDealerHand() string {
+	g := m.game
+	var scoreStr string
+	if g.HoleRevealed {
+		scoreStr = fmt.Sprintf("(%d)", g.DealerHand.Score())
+	} else if len(g.DealerHand.Cards) > 0 {
+		scoreStr = "(?)"
+	}
+
+	label := labelStyle.Render("Dealer " + scoreStr)
+
+	var cards string
+	if len(g.DealerHand.Cards) == 0 {
+		cards = ""
+	} else if g.HoleRevealed {
+		cards = renderCards(g.DealerHand.Cards)
+	} else {
+		shown := styledCard(g.DealerHand.Cards[0])
+		cards = shown + "  " + helpStyle.Render(holeCardText)
+	}
+
+	return label + "\n" + cards
+}
+
+func (m Model) renderPlayerHand() string {
+	g := m.game
+	var scoreStr string
+	if len(g.PlayerHand.Cards) > 0 {
+		scoreStr = fmt.Sprintf("(%d)", g.PlayerHand.Score())
+	}
+
+	label := labelStyle.Render("Player " + scoreStr)
+	cards := renderCards(g.PlayerHand.Cards)
+	return label + "\n" + cards
+}
+
+func renderCards(cards []Card) string {
+	parts := make([]string, len(cards))
+	for i, c := range cards {
+		parts[i] = styledCard(c)
+	}
+	return strings.Join(parts, "  ")
+}
+
+func styledCard(c Card) string {
+	rankStr := c.Rank.String()
+	suitStr := c.Suit.Symbol()
+	if c.Suit == Hearts || c.Suit == Diamonds {
+		return cardWhiteStyle.Render(rankStr) + cardRedStyle.Render(suitStr)
+	}
+	return cardWhiteStyle.Render(rankStr+suitStr)
+}
+
+func (m Model) renderStats() string {
+	g := m.game
+	balance := labelStyle.Render(fmt.Sprintf("Balance: $%d", g.Balance))
+	bet := ""
+	if g.Bet > 0 {
+		bet = labelStyle.Render(fmt.Sprintf("    Bet: $%d", g.Bet))
+	}
+	stats := labelStyle.Render(fmt.Sprintf("W: %d  L: %d  P: %d",
+		g.Stats.Wins, g.Stats.Losses, g.Stats.Pushes))
+	return balance + bet + "\n" + stats
+}
+
+func (m Model) renderMessage() string {
+	msg := m.game.Message
+	switch m.game.Outcome {
+	case OutcomePlayerWin, OutcomePlayerBlackjack:
+		return winStyle.Render(msg)
+	case OutcomeDealerWin:
+		return lossStyle.Render(msg)
+	case OutcomePush:
+		return pushStyle.Render(msg)
+	default:
+		return msg
+	}
+}
+
+func (m Model) renderHelp() string {
+	switch m.game.Phase {
+	case PhaseBetting:
+		return helpStyle.Render("[1] $10  [2] $25  [3] $50  [4] $100  [Q] Quit")
+	case PhasePlayerTurn:
+		help := "[H] Hit  [S] Stand"
+		if m.game.CanDoubleDown() {
+			help += "  [D] Double Down"
+		}
+		return helpStyle.Render(help)
+	case PhaseResult:
+		return helpStyle.Render("[Enter/N] New Round  [Q] Quit")
+	default:
+		return ""
+	}
+}
+
+// Done returns true when the player wants to return to the menu.
+func (m Model) Done() bool {
+	return m.done
+}

--- a/internal/menu/model.go
+++ b/internal/menu/model.go
@@ -158,6 +158,12 @@ func (m Model) Selected() int {
 	return m.selected
 }
 
+// ResetSelection clears the selected state so the menu can be reused
+// after returning from a game.
+func (m *Model) ResetSelection() {
+	m.selected = -1
+}
+
 // Quitting returns true if the user pressed quit.
 func (m Model) Quitting() bool {
 	return m.quitting

--- a/internal/yahtzee/game.go
+++ b/internal/yahtzee/game.go
@@ -1,0 +1,313 @@
+package yahtzee
+
+import (
+	"errors"
+	"math/rand/v2"
+	"sort"
+)
+
+// Category represents a Yahtzee scoring category.
+type Category int
+
+const (
+	Ones Category = iota
+	Twos
+	Threes
+	Fours
+	Fives
+	Sixes
+	ThreeOfAKind
+	FourOfAKind
+	FullHouse
+	SmallStraight
+	LargeStraight
+	YahtzeeScore
+	Chance
+	NumCategories // sentinel = 13
+)
+
+var categoryNames = [NumCategories]string{
+	"Ones", "Twos", "Threes", "Fours", "Fives", "Sixes",
+	"Three of a Kind", "Four of a Kind", "Full House",
+	"Small Straight", "Large Straight", "Yahtzee", "Chance",
+}
+
+// Name returns the display name of the category.
+func (c Category) Name() string {
+	if c >= 0 && c < NumCategories {
+		return categoryNames[c]
+	}
+	return "Unknown"
+}
+
+// IsUpper returns true for the upper section (Ones through Sixes).
+func (c Category) IsUpper() bool {
+	return c >= Ones && c <= Sixes
+}
+
+// Dice holds the values and hold state of 5 dice.
+type Dice struct {
+	Values [5]int
+	Held   [5]bool
+}
+
+// Scorecard tracks which categories have been scored and their values.
+type Scorecard struct {
+	Scores [NumCategories]int
+	Used   [NumCategories]bool
+}
+
+// Game holds the complete state of a Yahtzee game.
+type Game struct {
+	Dice           Dice
+	Scorecard      Scorecard
+	RollsLeft      int
+	Turn           int
+	YahtzeeBonuses int
+	GameOver       bool
+}
+
+// NewGame creates a fresh game ready to play.
+func NewGame() *Game {
+	return &Game{
+		RollsLeft: 3,
+		Turn:      1,
+	}
+}
+
+// Roll rolls all non-held dice. On the first roll of a turn, held flags are cleared.
+func (g *Game) Roll() {
+	if !g.CanRoll() {
+		return
+	}
+	if g.RollsLeft == 3 {
+		g.Dice.Held = [5]bool{}
+	}
+	for i := 0; i < 5; i++ {
+		if !g.Dice.Held[i] {
+			g.Dice.Values[i] = rand.IntN(6) + 1
+		}
+	}
+	g.RollsLeft--
+}
+
+// CanRoll returns true if the player has rolls remaining.
+func (g *Game) CanRoll() bool {
+	return g.RollsLeft > 0
+}
+
+// ToggleHold flips the held state of the die at the given index.
+func (g *Game) ToggleHold(index int) {
+	if index < 0 || index > 4 || !g.CanHold() {
+		return
+	}
+	g.Dice.Held[index] = !g.Dice.Held[index]
+}
+
+// CanHold returns true if at least one roll has been made this turn.
+func (g *Game) CanHold() bool {
+	return g.RollsLeft < 3
+}
+
+// CanScore returns true if at least one roll has been made this turn.
+func (g *Game) CanScore() bool {
+	return g.RollsLeft < 3
+}
+
+// Score assigns the current dice to the given category.
+func (g *Game) Score(cat Category) error {
+	if cat < 0 || cat >= NumCategories {
+		return errors.New("invalid category")
+	}
+	if g.Scorecard.Used[cat] {
+		return errors.New("category already used")
+	}
+	if !g.CanScore() {
+		return errors.New("must roll at least once before scoring")
+	}
+
+	// Check Yahtzee bonus: current dice are Yahtzee, YahtzeeScore already used with 50.
+	if isYahtzee(g.Dice.Values) && g.Scorecard.Used[YahtzeeScore] && g.Scorecard.Scores[YahtzeeScore] == 50 {
+		g.YahtzeeBonuses++
+	}
+
+	g.Scorecard.Scores[cat] = ScoreCategory(g.Dice.Values, cat)
+	g.Scorecard.Used[cat] = true
+
+	g.Turn++
+	g.RollsLeft = 3
+	g.Dice.Held = [5]bool{}
+	g.Dice.Values = [5]int{}
+
+	if g.Turn > 13 {
+		g.GameOver = true
+	}
+	return nil
+}
+
+// ScoreCategory calculates the score for a set of dice in a given category.
+func ScoreCategory(dice [5]int, cat Category) int {
+	switch cat {
+	case Ones:
+		return scoreUpper(dice, 1)
+	case Twos:
+		return scoreUpper(dice, 2)
+	case Threes:
+		return scoreUpper(dice, 3)
+	case Fours:
+		return scoreUpper(dice, 4)
+	case Fives:
+		return scoreUpper(dice, 5)
+	case Sixes:
+		return scoreUpper(dice, 6)
+	case ThreeOfAKind:
+		return scoreNOfAKind(dice, 3)
+	case FourOfAKind:
+		return scoreNOfAKind(dice, 4)
+	case FullHouse:
+		return scoreFullHouse(dice)
+	case SmallStraight:
+		return scoreSmallStraight(dice)
+	case LargeStraight:
+		return scoreLargeStraight(dice)
+	case YahtzeeScore:
+		return scoreYahtzee(dice)
+	case Chance:
+		return scoreChance(dice)
+	}
+	return 0
+}
+
+func scoreUpper(dice [5]int, target int) int {
+	total := 0
+	for _, v := range dice {
+		if v == target {
+			total += v
+		}
+	}
+	return total
+}
+
+func scoreNOfAKind(dice [5]int, n int) int {
+	c := counts(dice)
+	for v := 1; v <= 6; v++ {
+		if c[v] >= n {
+			return scoreChance(dice)
+		}
+	}
+	return 0
+}
+
+func scoreFullHouse(dice [5]int) int {
+	c := counts(dice)
+	hasTwo, hasThree := false, false
+	for v := 1; v <= 6; v++ {
+		if c[v] == 2 {
+			hasTwo = true
+		}
+		if c[v] == 3 {
+			hasThree = true
+		}
+	}
+	if hasTwo && hasThree {
+		return 25
+	}
+	return 0
+}
+
+func scoreSmallStraight(dice [5]int) int {
+	has := [7]bool{}
+	for _, v := range dice {
+		has[v] = true
+	}
+	for start := 1; start <= 3; start++ {
+		if has[start] && has[start+1] && has[start+2] && has[start+3] {
+			return 30
+		}
+	}
+	return 0
+}
+
+func scoreLargeStraight(dice [5]int) int {
+	s := sortedDice(dice)
+	if (s == [5]int{1, 2, 3, 4, 5}) || (s == [5]int{2, 3, 4, 5, 6}) {
+		return 40
+	}
+	return 0
+}
+
+func scoreYahtzee(dice [5]int) int {
+	if isYahtzee(dice) {
+		return 50
+	}
+	return 0
+}
+
+func scoreChance(dice [5]int) int {
+	total := 0
+	for _, v := range dice {
+		total += v
+	}
+	return total
+}
+
+// UpperTotal returns the sum of scored upper section categories.
+func (s *Scorecard) UpperTotal() int {
+	total := 0
+	for cat := Ones; cat <= Sixes; cat++ {
+		if s.Used[cat] {
+			total += s.Scores[cat]
+		}
+	}
+	return total
+}
+
+// UpperBonus returns 35 if the upper total is 63 or more, else 0.
+func (s *Scorecard) UpperBonus() int {
+	if s.UpperTotal() >= 63 {
+		return 35
+	}
+	return 0
+}
+
+// LowerTotal returns the sum of scored lower section categories.
+func (s *Scorecard) LowerTotal() int {
+	total := 0
+	for cat := ThreeOfAKind; cat <= Chance; cat++ {
+		if s.Used[cat] {
+			total += s.Scores[cat]
+		}
+	}
+	return total
+}
+
+// GrandTotal returns the complete game score.
+func (g *Game) GrandTotal() int {
+	return g.Scorecard.UpperTotal() + g.Scorecard.UpperBonus() +
+		g.Scorecard.LowerTotal() + g.YahtzeeBonuses*100
+}
+
+func counts(dice [5]int) [7]int {
+	var c [7]int
+	for _, v := range dice {
+		if v >= 1 && v <= 6 {
+			c[v]++
+		}
+	}
+	return c
+}
+
+func sortedDice(dice [5]int) [5]int {
+	s := dice
+	sort.Ints(s[:])
+	return s
+}
+
+func isYahtzee(dice [5]int) bool {
+	for i := 1; i < 5; i++ {
+		if dice[i] != dice[0] {
+			return false
+		}
+	}
+	return dice[0] >= 1
+}

--- a/internal/yahtzee/game_test.go
+++ b/internal/yahtzee/game_test.go
@@ -1,0 +1,426 @@
+package yahtzee
+
+import "testing"
+
+// setDice sets dice values and ensures at least one roll has been made.
+func setDice(g *Game, values [5]int) {
+	g.Dice.Values = values
+	if g.RollsLeft == 3 {
+		g.RollsLeft = 2
+	}
+}
+
+func TestScoreUpper(t *testing.T) {
+	tests := []struct {
+		name     string
+		dice     [5]int
+		category Category
+		want     int
+	}{
+		{"ones in mixed", [5]int{1, 1, 2, 3, 4}, Ones, 2},
+		{"twos in mixed", [5]int{1, 1, 2, 3, 4}, Twos, 2},
+		{"threes in mixed", [5]int{1, 1, 2, 3, 4}, Threes, 3},
+		{"fours in mixed", [5]int{1, 1, 2, 3, 4}, Fours, 4},
+		{"fives in mixed", [5]int{1, 1, 2, 3, 4}, Fives, 0},
+		{"sixes in mixed", [5]int{1, 1, 2, 3, 4}, Sixes, 0},
+		{"all sixes", [5]int{6, 6, 6, 6, 6}, Sixes, 30},
+		{"no match", [5]int{2, 3, 4, 5, 6}, Ones, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScoreCategory(tt.dice, tt.category)
+			if got != tt.want {
+				t.Errorf("ScoreCategory(%v, %s) = %d, want %d", tt.dice, tt.category.Name(), got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScoreThreeOfAKind(t *testing.T) {
+	tests := []struct {
+		name string
+		dice [5]int
+		want int
+	}{
+		{"three threes", [5]int{3, 3, 3, 1, 2}, 12},
+		{"no three of a kind", [5]int{3, 3, 2, 1, 4}, 0},
+		{"four of a kind qualifies", [5]int{5, 5, 5, 5, 1}, 21},
+		{"yahtzee qualifies", [5]int{2, 2, 2, 2, 2}, 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScoreCategory(tt.dice, ThreeOfAKind)
+			if got != tt.want {
+				t.Errorf("ScoreCategory(%v, ThreeOfAKind) = %d, want %d", tt.dice, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScoreFourOfAKind(t *testing.T) {
+	tests := []struct {
+		name string
+		dice [5]int
+		want int
+	}{
+		{"four fours", [5]int{4, 4, 4, 4, 2}, 18},
+		{"only three", [5]int{4, 4, 4, 3, 2}, 0},
+		{"yahtzee qualifies", [5]int{6, 6, 6, 6, 6}, 30},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScoreCategory(tt.dice, FourOfAKind)
+			if got != tt.want {
+				t.Errorf("ScoreCategory(%v, FourOfAKind) = %d, want %d", tt.dice, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScoreFullHouse(t *testing.T) {
+	tests := []struct {
+		name string
+		dice [5]int
+		want int
+	}{
+		{"three and two", [5]int{3, 3, 3, 2, 2}, 25},
+		{"four of a kind not full house", [5]int{3, 3, 3, 3, 2}, 0},
+		{"yahtzee not full house", [5]int{1, 1, 1, 1, 1}, 0},
+		{"different full house", [5]int{5, 5, 6, 6, 6}, 25},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScoreCategory(tt.dice, FullHouse)
+			if got != tt.want {
+				t.Errorf("ScoreCategory(%v, FullHouse) = %d, want %d", tt.dice, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScoreSmallStraight(t *testing.T) {
+	tests := []struct {
+		name string
+		dice [5]int
+		want int
+	}{
+		{"1-2-3-4 with 6", [5]int{1, 2, 3, 4, 6}, 30},
+		{"2-3-4-5 scrambled", [5]int{2, 3, 4, 5, 1}, 30},
+		{"3-4-5-6 with dup", [5]int{3, 4, 5, 6, 3}, 30},
+		{"gap in sequence", [5]int{1, 2, 3, 5, 6}, 0},
+		{"all same", [5]int{4, 4, 4, 4, 4}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScoreCategory(tt.dice, SmallStraight)
+			if got != tt.want {
+				t.Errorf("ScoreCategory(%v, SmallStraight) = %d, want %d", tt.dice, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScoreLargeStraight(t *testing.T) {
+	tests := []struct {
+		name string
+		dice [5]int
+		want int
+	}{
+		{"1-2-3-4-5", [5]int{1, 2, 3, 4, 5}, 40},
+		{"2-3-4-5-6", [5]int{2, 3, 4, 5, 6}, 40},
+		{"only small straight", [5]int{1, 2, 3, 4, 6}, 0},
+		{"scrambled large", [5]int{5, 3, 1, 4, 2}, 40},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScoreCategory(tt.dice, LargeStraight)
+			if got != tt.want {
+				t.Errorf("ScoreCategory(%v, LargeStraight) = %d, want %d", tt.dice, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScoreYahtzee(t *testing.T) {
+	tests := []struct {
+		name string
+		dice [5]int
+		want int
+	}{
+		{"all fives", [5]int{5, 5, 5, 5, 5}, 50},
+		{"not yahtzee", [5]int{5, 5, 5, 5, 4}, 0},
+		{"all ones", [5]int{1, 1, 1, 1, 1}, 50},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScoreCategory(tt.dice, YahtzeeScore)
+			if got != tt.want {
+				t.Errorf("ScoreCategory(%v, Yahtzee) = %d, want %d", tt.dice, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScoreChance(t *testing.T) {
+	tests := []struct {
+		name string
+		dice [5]int
+		want int
+	}{
+		{"sequential", [5]int{1, 2, 3, 4, 5}, 15},
+		{"all sixes", [5]int{6, 6, 6, 6, 6}, 30},
+		{"mixed", [5]int{1, 1, 1, 1, 1}, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ScoreCategory(tt.dice, Chance)
+			if got != tt.want {
+				t.Errorf("ScoreCategory(%v, Chance) = %d, want %d", tt.dice, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpperBonus(t *testing.T) {
+	tests := []struct {
+		name  string
+		total int
+		want  int
+	}{
+		{"exactly 63", 63, 35},
+		{"above 63", 80, 35},
+		{"below 63", 62, 0},
+		{"zero", 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := &Scorecard{}
+			// Distribute the total across upper categories to reach desired amount.
+			// Use Sixes to hold the bulk.
+			if tt.total > 0 {
+				sc.Used[Sixes] = true
+				sc.Scores[Sixes] = tt.total
+			}
+			got := sc.UpperBonus()
+			if got != tt.want {
+				t.Errorf("UpperBonus() with total %d = %d, want %d", tt.total, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestYahtzeeBonus(t *testing.T) {
+	t.Run("bonus after scoring yahtzee 50", func(t *testing.T) {
+		g := NewGame()
+		// Score a Yahtzee first
+		setDice(g, [5]int{5, 5, 5, 5, 5})
+		if err := g.Score(YahtzeeScore); err != nil {
+			t.Fatalf("scoring yahtzee: %v", err)
+		}
+		if g.Scorecard.Scores[YahtzeeScore] != 50 {
+			t.Fatalf("expected yahtzee score 50, got %d", g.Scorecard.Scores[YahtzeeScore])
+		}
+
+		// Roll another Yahtzee and score in chance
+		setDice(g, [5]int{3, 3, 3, 3, 3})
+		if err := g.Score(Chance); err != nil {
+			t.Fatalf("scoring chance: %v", err)
+		}
+		if g.YahtzeeBonuses != 1 {
+			t.Errorf("expected 1 yahtzee bonus, got %d", g.YahtzeeBonuses)
+		}
+	})
+
+	t.Run("no bonus when yahtzee scored as zero", func(t *testing.T) {
+		g := NewGame()
+		// Score a zero in Yahtzee (not a yahtzee roll)
+		setDice(g, [5]int{1, 2, 3, 4, 5})
+		if err := g.Score(YahtzeeScore); err != nil {
+			t.Fatalf("scoring yahtzee as zero: %v", err)
+		}
+		if g.Scorecard.Scores[YahtzeeScore] != 0 {
+			t.Fatalf("expected yahtzee score 0, got %d", g.Scorecard.Scores[YahtzeeScore])
+		}
+
+		// Roll a real Yahtzee — no bonus because original was 0
+		setDice(g, [5]int{4, 4, 4, 4, 4})
+		if err := g.Score(Chance); err != nil {
+			t.Fatalf("scoring chance: %v", err)
+		}
+		if g.YahtzeeBonuses != 0 {
+			t.Errorf("expected 0 yahtzee bonuses, got %d", g.YahtzeeBonuses)
+		}
+	})
+}
+
+func TestTurnFlow(t *testing.T) {
+	g := NewGame()
+
+	// Initial state
+	if g.RollsLeft != 3 {
+		t.Fatalf("expected 3 rolls, got %d", g.RollsLeft)
+	}
+	if g.Turn != 1 {
+		t.Fatalf("expected turn 1, got %d", g.Turn)
+	}
+
+	// Cannot hold before rolling
+	if g.CanHold() {
+		t.Error("should not be able to hold before rolling")
+	}
+
+	// Roll decrements
+	g.Roll()
+	if g.RollsLeft != 2 {
+		t.Errorf("expected 2 rolls left, got %d", g.RollsLeft)
+	}
+
+	// Can hold after rolling
+	if !g.CanHold() {
+		t.Error("should be able to hold after rolling")
+	}
+
+	// Toggle hold
+	g.ToggleHold(0)
+	if !g.Dice.Held[0] {
+		t.Error("die 0 should be held")
+	}
+	g.ToggleHold(0)
+	if g.Dice.Held[0] {
+		t.Error("die 0 should be released")
+	}
+
+	// Roll again
+	g.Roll()
+	if g.RollsLeft != 1 {
+		t.Errorf("expected 1 roll left, got %d", g.RollsLeft)
+	}
+
+	// Last roll
+	g.Roll()
+	if g.RollsLeft != 0 {
+		t.Errorf("expected 0 rolls left, got %d", g.RollsLeft)
+	}
+
+	// Cannot roll anymore
+	if g.CanRoll() {
+		t.Error("should not be able to roll with 0 rolls left")
+	}
+
+	// Score advances turn
+	if err := g.Score(Ones); err != nil {
+		t.Fatalf("scoring: %v", err)
+	}
+	if g.Turn != 2 {
+		t.Errorf("expected turn 2, got %d", g.Turn)
+	}
+	if g.RollsLeft != 3 {
+		t.Errorf("expected 3 rolls for new turn, got %d", g.RollsLeft)
+	}
+}
+
+func TestGameOver(t *testing.T) {
+	g := NewGame()
+	for cat := Category(0); cat < NumCategories; cat++ {
+		setDice(g, [5]int{1, 2, 3, 4, 5})
+		if err := g.Score(cat); err != nil {
+			t.Fatalf("scoring category %s: %v", cat.Name(), err)
+		}
+	}
+	if !g.GameOver {
+		t.Error("game should be over after 13 categories")
+	}
+	if g.Turn != 14 {
+		t.Errorf("expected turn 14, got %d", g.Turn)
+	}
+}
+
+func TestGrandTotal(t *testing.T) {
+	g := NewGame()
+
+	// Manually set upper section to exactly 63 (3*1 + 3*2 + 3*3 + 3*4 + 3*5 + 3*6 = 63)
+	g.Scorecard.Used[Ones] = true
+	g.Scorecard.Scores[Ones] = 3
+	g.Scorecard.Used[Twos] = true
+	g.Scorecard.Scores[Twos] = 6
+	g.Scorecard.Used[Threes] = true
+	g.Scorecard.Scores[Threes] = 9
+	g.Scorecard.Used[Fours] = true
+	g.Scorecard.Scores[Fours] = 12
+	g.Scorecard.Used[Fives] = true
+	g.Scorecard.Scores[Fives] = 15
+	g.Scorecard.Used[Sixes] = true
+	g.Scorecard.Scores[Sixes] = 18
+
+	// Lower section
+	g.Scorecard.Used[FullHouse] = true
+	g.Scorecard.Scores[FullHouse] = 25
+	g.Scorecard.Used[YahtzeeScore] = true
+	g.Scorecard.Scores[YahtzeeScore] = 50
+
+	// Add a Yahtzee bonus
+	g.YahtzeeBonuses = 1
+
+	// Upper: 63, Bonus: 35, Lower: 25+50=75, YahtzeeBonus: 100
+	expected := 63 + 35 + 75 + 100
+	got := g.GrandTotal()
+	if got != expected {
+		t.Errorf("GrandTotal() = %d, want %d", got, expected)
+	}
+}
+
+func TestScoreErrors(t *testing.T) {
+	t.Run("cannot score before rolling", func(t *testing.T) {
+		g := NewGame()
+		err := g.Score(Ones)
+		if err == nil {
+			t.Error("expected error when scoring before rolling")
+		}
+	})
+
+	t.Run("cannot score same category twice", func(t *testing.T) {
+		g := NewGame()
+		setDice(g, [5]int{1, 1, 1, 1, 1})
+		if err := g.Score(Ones); err != nil {
+			t.Fatalf("first score: %v", err)
+		}
+		setDice(g, [5]int{1, 1, 1, 1, 1})
+		err := g.Score(Ones)
+		if err == nil {
+			t.Error("expected error when scoring same category twice")
+		}
+	})
+}
+
+func TestCategoryName(t *testing.T) {
+	tests := []struct {
+		cat  Category
+		want string
+	}{
+		{Ones, "Ones"},
+		{YahtzeeScore, "Yahtzee"},
+		{Chance, "Chance"},
+		{FullHouse, "Full House"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.cat.Name()
+			if got != tt.want {
+				t.Errorf("Category(%d).Name() = %q, want %q", tt.cat, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsUpper(t *testing.T) {
+	for cat := Ones; cat <= Sixes; cat++ {
+		if !cat.IsUpper() {
+			t.Errorf("%s should be upper", cat.Name())
+		}
+	}
+	for cat := ThreeOfAKind; cat <= Chance; cat++ {
+		if cat.IsUpper() {
+			t.Errorf("%s should not be upper", cat.Name())
+		}
+	}
+}

--- a/internal/yahtzee/model.go
+++ b/internal/yahtzee/model.go
@@ -1,0 +1,443 @@
+package yahtzee
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type phase int
+
+const (
+	phaseRolling  phase = iota // Rolling dice, toggling holds
+	phaseScoring               // Selecting category to score
+	phaseGameOver              // Final score displayed
+)
+
+// Model is the Bubbletea model for the Yahtzee game.
+type Model struct {
+	game    *Game
+	phase   phase
+	cursor  int
+	width   int
+	height  int
+	done    bool
+	message string
+}
+
+// New creates a fresh Yahtzee model.
+func New() Model {
+	return Model{
+		game:  NewGame(),
+		phase: phaseRolling,
+	}
+}
+
+// Init returns nil; no initial command needed.
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles input and advances game state.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		key := msg.String()
+
+		if key == "ctrl+c" {
+			return m, tea.Quit
+		}
+
+		switch m.phase {
+		case phaseRolling:
+			return m.updateRolling(key)
+		case phaseScoring:
+			return m.updateScoring(key)
+		case phaseGameOver:
+			return m.updateGameOver(key)
+		}
+	}
+
+	return m, nil
+}
+
+func (m Model) updateRolling(key string) (tea.Model, tea.Cmd) {
+	switch key {
+	case "r", " ":
+		if m.game.CanRoll() {
+			m.game.Roll()
+			m.message = fmt.Sprintf("Rolled! %d rolls left", m.game.RollsLeft)
+		} else {
+			m.message = "No rolls left — select a category"
+		}
+	case "1", "2", "3", "4", "5":
+		idx := int(key[0]-'0') - 1
+		if m.game.CanHold() {
+			m.game.ToggleHold(idx)
+			if m.game.Dice.Held[idx] {
+				m.message = fmt.Sprintf("Holding die %d", idx+1)
+			} else {
+				m.message = fmt.Sprintf("Released die %d", idx+1)
+			}
+		} else {
+			m.message = "Roll first before holding dice"
+		}
+	case "tab", "enter":
+		if m.game.CanScore() {
+			m.phase = phaseScoring
+			m.cursor = m.firstUnusedCategory()
+			m.message = "Select a category to score"
+		} else {
+			m.message = "Roll first"
+		}
+	case "q", "esc":
+		m.done = true
+	}
+	return m, nil
+}
+
+func (m Model) updateScoring(key string) (tea.Model, tea.Cmd) {
+	switch key {
+	case "up", "k":
+		m.cursor = m.nextUnusedCategory(-1)
+	case "down", "j":
+		m.cursor = m.nextUnusedCategory(1)
+	case "enter":
+		cat := Category(m.cursor)
+		if err := m.game.Score(cat); err != nil {
+			m.message = err.Error()
+		} else if m.game.GameOver {
+			m.phase = phaseGameOver
+			m.message = fmt.Sprintf("Game over! Final score: %d", m.game.GrandTotal())
+		} else {
+			m.phase = phaseRolling
+			m.message = fmt.Sprintf("Turn %d — press R to roll", m.game.Turn)
+		}
+	case "tab":
+		if m.game.CanRoll() {
+			m.phase = phaseRolling
+			m.message = ""
+		}
+	case "q", "esc":
+		m.done = true
+	}
+	return m, nil
+}
+
+func (m Model) updateGameOver(key string) (tea.Model, tea.Cmd) {
+	switch key {
+	case "enter", "r":
+		m.game = NewGame()
+		m.phase = phaseRolling
+		m.message = "New game! Press R to roll"
+		m.cursor = 0
+	case "q", "esc":
+		m.done = true
+	}
+	return m, nil
+}
+
+// Done returns true when the player wants to exit.
+func (m Model) Done() bool {
+	return m.done
+}
+
+// View renders the complete game screen.
+func (m Model) View() string {
+	var sections []string
+
+	// Title
+	title := titleStyle.Render("Y A H T Z E E")
+	sections = append(sections, title)
+
+	// Turn info
+	turnInfo := turnStyle.Render(fmt.Sprintf("Turn %d/13  |  Rolls left: %d", m.game.Turn, m.game.RollsLeft))
+	sections = append(sections, turnInfo)
+
+	sections = append(sections, "")
+
+	// Dice and scorecard side by side
+	diceBlock := renderDice(m.game.Dice)
+	scorecardBlock := m.renderScorecard()
+
+	middle := lipgloss.JoinHorizontal(lipgloss.Top, diceBlock, "    ", scorecardBlock)
+	sections = append(sections, middle)
+
+	sections = append(sections, "")
+
+	// Message
+	if m.message != "" {
+		sections = append(sections, messageStyle.Render(m.message))
+	} else {
+		sections = append(sections, "")
+	}
+
+	// Footer controls
+	var footer string
+	switch m.phase {
+	case phaseRolling:
+		footer = "R Roll  |  1-5 Hold/Release  |  Tab Score  |  Q Quit"
+	case phaseScoring:
+		footer = "↑↓ Select  |  Enter Confirm  |  Tab Back  |  Q Quit"
+	case phaseGameOver:
+		footer = "Enter New Game  |  Q Quit"
+	}
+	sections = append(sections, footerStyle.Render(footer))
+
+	content := lipgloss.JoinVertical(lipgloss.Center, sections...)
+
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+}
+
+// --- Dice rendering ---
+
+func diceFace(value int) [5]string {
+	blank := "     "
+	left := " *   "
+	center := "  *  "
+	right := "   * "
+	leftRight := " * * "
+	triLeft := " *   "
+	triRight := "   * "
+
+	var rows [3]string // inner rows only (top, middle, bottom)
+
+	switch value {
+	case 1:
+		rows = [3]string{blank, center, blank}
+	case 2:
+		rows = [3]string{right, blank, left}
+	case 3:
+		rows = [3]string{right, center, left}
+	case 4:
+		rows = [3]string{leftRight, blank, leftRight}
+	case 5:
+		rows = [3]string{leftRight, center, leftRight}
+	case 6:
+		rows = [3]string{leftRight, leftRight, leftRight}
+	default:
+		rows = [3]string{blank, blank, blank}
+	}
+
+	_ = triLeft
+	_ = triRight
+
+	return [5]string{
+		"┌─────┐",
+		"│" + rows[0] + "│",
+		"│" + rows[1] + "│",
+		"│" + rows[2] + "│",
+		"└─────┘",
+	}
+}
+
+func renderDice(d Dice) string {
+	if d.Values == [5]int{} {
+		return dimStyle.Render("  Press R to roll the dice")
+	}
+
+	// Build each die face and label
+	faces := [5][5]string{}
+	for i := 0; i < 5; i++ {
+		faces[i] = diceFace(d.Values[i])
+	}
+
+	// Render each row across all dice
+	var lines []string
+	for row := 0; row < 5; row++ {
+		var parts []string
+		for i := 0; i < 5; i++ {
+			var style lipgloss.Style
+			if d.Held[i] {
+				style = heldDieStyle
+			} else {
+				style = freeDieStyle
+			}
+			parts = append(parts, style.Render(faces[i][row]))
+		}
+		lines = append(lines, strings.Join(parts, " "))
+	}
+
+	// Labels below dice
+	var labels []string
+	for i := 0; i < 5; i++ {
+		label := fmt.Sprintf("  [%d]  ", i+1)
+		if d.Held[i] {
+			labels = append(labels, heldLabelStyle.Render(label))
+		} else {
+			labels = append(labels, dimStyle.Render(label))
+		}
+	}
+	lines = append(lines, strings.Join(labels, " "))
+
+	return strings.Join(lines, "\n")
+}
+
+// --- Scorecard rendering ---
+
+func (m Model) renderScorecard() string {
+	var left, right []string
+
+	left = append(left, headerStyle.Render("UPPER SECTION"))
+	right = append(right, headerStyle.Render("LOWER SECTION"))
+
+	// Upper section
+	for cat := Ones; cat <= Sixes; cat++ {
+		left = append(left, m.renderCategoryLine(cat))
+	}
+
+	// Upper totals
+	upperTotal := m.game.Scorecard.UpperTotal()
+	left = append(left, "")
+	left = append(left, dimStyle.Render(fmt.Sprintf("Upper Total ... %d/63", upperTotal)))
+	bonus := m.game.Scorecard.UpperBonus()
+	if bonus > 0 {
+		left = append(left, potentialStyle.Render(fmt.Sprintf("Bonus ......... %d", bonus)))
+	} else {
+		left = append(left, dimStyle.Render("Bonus ......... -"))
+	}
+
+	// Lower section
+	for cat := ThreeOfAKind; cat <= Chance; cat++ {
+		right = append(right, m.renderCategoryLine(cat))
+	}
+
+	// Yahtzee bonus and total
+	right = append(right, "")
+	if m.game.YahtzeeBonuses > 0 {
+		right = append(right, potentialStyle.Render(fmt.Sprintf("Yahtzee Bonus . %d", m.game.YahtzeeBonuses*100)))
+	} else {
+		right = append(right, dimStyle.Render("Yahtzee Bonus . -"))
+	}
+	right = append(right, categoryNameStyle.Render(fmt.Sprintf("TOTAL ......... %d", m.game.GrandTotal())))
+
+	// Pad shorter column
+	for len(left) < len(right) {
+		left = append(left, "")
+	}
+	for len(right) < len(left) {
+		right = append(right, "")
+	}
+
+	leftCol := strings.Join(left, "\n")
+	rightCol := strings.Join(right, "\n")
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, leftCol, "   ", rightCol)
+}
+
+func (m Model) renderCategoryLine(cat Category) string {
+	name := cat.Name()
+	// Pad name to consistent width
+	padded := name + strings.Repeat(".", 20-len(name))
+
+	if m.game.Scorecard.Used[cat] {
+		val := m.game.Scorecard.Scores[cat]
+		if val == 0 {
+			return zeroScoreStyle.Render(padded+" ") + zeroScoreStyle.Render("0")
+		}
+		return categoryNameStyle.Render(padded+" ") + scoredStyle.Render(fmt.Sprintf("%d", val))
+	}
+
+	// Show potential score
+	potential := ""
+	if m.game.CanScore() {
+		p := ScoreCategory(m.game.Dice.Values, cat)
+		potential = fmt.Sprintf("[%d]", p)
+	} else {
+		potential = " -"
+	}
+
+	isCursor := m.phase == phaseScoring && int(cat) == m.cursor
+
+	if isCursor {
+		return cursorCatStyle.Render(padded+" ") + cursorCatStyle.Render(potential) + cursorCatStyle.Render(" <")
+	}
+	return categoryNameStyle.Render(padded+" ") + potentialStyle.Render(potential)
+}
+
+// --- Cursor navigation ---
+
+func (m Model) firstUnusedCategory() int {
+	for i := 0; i < int(NumCategories); i++ {
+		if !m.game.Scorecard.Used[i] {
+			return i
+		}
+	}
+	return 0
+}
+
+func (m Model) nextUnusedCategory(direction int) int {
+	start := m.cursor
+	pos := start
+	for range int(NumCategories) {
+		pos += direction
+		if pos < 0 {
+			pos = int(NumCategories) - 1
+		}
+		if pos >= int(NumCategories) {
+			pos = 0
+		}
+		if !m.game.Scorecard.Used[pos] {
+			return pos
+		}
+	}
+	return start
+}
+
+// --- Styles ---
+
+var (
+	titleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("15"))
+
+	turnStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("242"))
+
+	headerStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("15")).
+			Underline(true)
+
+	categoryNameStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("15"))
+
+	scoredStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("15"))
+
+	zeroScoreStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240"))
+
+	potentialStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#00E632"))
+
+	cursorCatStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FFD700")).
+			Bold(true)
+
+	heldDieStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FFD700"))
+
+	freeDieStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("242"))
+
+	heldLabelStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FFD700")).
+			Bold(true)
+
+	dimStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240"))
+
+	messageStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#DCFFDC"))
+
+	footerStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240"))
+)


### PR DESCRIPTION
## Summary

- **Yahtzee**: Full 13-category scoring, ASCII dice art with held/free states, upper bonus (35 if ≥63), Yahtzee bonus (100 per additional), 3 rolls per turn
- **Blackjack**: Standard rules with hit/stand/double down, dealer hits on <17, ace reduction, 3:2 blackjack payout, balance tracking (1000 starting chips)
- **App wiring**: `gameModel` interface (`tea.Model` + `Done()`) for generic game-to-menu routing
- **Menu**: `ResetSelection()` for returning from games
- **README**: Project description, install instructions, game status table, credits

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/blackjack/...` — 31 test cases passing
- [x] `go test ./internal/yahtzee/...` — all scoring categories + turn flow tested
- [ ] Manual: splash → menu → Yahtzee (play 13 turns) → menu
- [ ] Manual: splash → menu → Blackjack (bet, play, quit) → menu → Q to exit
- [ ] Manual: select unimplemented game → returns to menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)