### PR TITLE
feat: menu polish with categories, animations, and preview panel

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -162,7 +162,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.game = nil
 			m.active = screenMenu
 			m.menu.ResetSelection()
-			return m, nil
+			m.menu.IncrementGamesPlayed()
+			m.menu.TriggerEntrance()
+			return m, menu.AnimCmd()
 		}
 		return m, cmd
 	}

--- a/internal/menu/data.go
+++ b/internal/menu/data.go
@@ -1,0 +1,141 @@
+package menu
+
+// gameIcon maps a game index (from the Games slice) to a display icon.
+var gameIcon = map[int]string{
+	0:  "\u2684",       // Yahtzee: die face 5
+	1:  "\u2660",       // Blackjack: spade
+	2:  "Aa",           // Wordle
+	3:  "\u2731",       // Minesweeper: heavy asterisk
+	4:  "#",            // Sudoku
+	5:  "\u229e",       // 2048: squared plus
+	6:  "\u2620",       // Hangman: skull
+	7:  "\u2715",       // Tic-Tac-Toe: multiplication X
+	8:  "\u25cf",       // Mastermind: black circle
+	9:  "\u2666\u2666", // Memory: diamonds
+	10: "\u25c9",       // Connect Four: fisheye
+	11: "\u22a1",       // Fifteen Puzzle: squared dot
+	12: "~",            // Snake
+	13: "\u259f",       // Tetris: quadrant lower right
+	14: "\u2663",       // Solitaire: club
+	15: "\u2328",       // Typing Test: keyboard
+}
+
+// category groups games by theme. Each category references game indices
+// from the original Games slice (preserving launch indices).
+type category struct {
+	Name    string
+	Icon    string
+	Indices []int
+}
+
+var categories = []category{
+	{Name: "Classic", Icon: "\U0001f3b2", Indices: []int{0, 1, 14}},          // Yahtzee, Blackjack, Solitaire
+	{Name: "Puzzles", Icon: "\U0001f9e9", Indices: []int{2, 3, 4, 5, 11, 8}}, // Wordle, Minesweeper, Sudoku, 2048, Fifteen Puzzle, Mastermind
+	{Name: "Action", Icon: "\U0001f3ae", Indices: []int{12, 13}},             // Snake, Tetris
+	{Name: "Strategy", Icon: "\U0001f0cf", Indices: []int{6, 7, 10, 9}},      // Hangman, Tic-Tac-Toe, Connect Four, Memory
+	{Name: "Skills", Icon: "\u2328\ufe0f", Indices: []int{15}},               // Typing Test
+}
+
+// gamePreview holds the info panel text for each game.
+type gamePreview struct {
+	Rules    string
+	Controls string
+}
+
+var previews = map[int]gamePreview{
+	0: {
+		Rules:    "Roll 5 dice up to 3 times per turn.\nFill 13 scoring categories.\nHighest total score wins.",
+		Controls: "Space: roll | 1-5: hold dice | Enter: score",
+	},
+	1: {
+		Rules:    "Get closer to 21 than the dealer\nwithout going over. Aces are 1 or 11.\nBlackjack (21 in 2 cards) pays extra.",
+		Controls: "H: hit | S: stand | D: double down",
+	},
+	2: {
+		Rules:    "Guess a 5-letter word in 6 tries.\nGreen = right letter, right spot.\nYellow = right letter, wrong spot.",
+		Controls: "Type letters | Enter: submit | Backspace",
+	},
+	3: {
+		Rules:    "Uncover all safe cells without\nhitting a mine. Numbers show how\nmany mines are adjacent.",
+		Controls: "Arrows: move | Space: reveal | F: flag",
+	},
+	4: {
+		Rules:    "Fill every row, column, and 3x3 box\nwith digits 1-9. No repeats allowed\nin any group.",
+		Controls: "Arrows: move | 1-9: place | 0: clear",
+	},
+	5: {
+		Rules:    "Slide tiles to merge matching\nnumbers. Reach 2048 to win.\nGame over when no moves remain.",
+		Controls: "Arrow keys to slide all tiles",
+	},
+	6: {
+		Rules:    "Guess the hidden word one letter\nat a time. Too many wrong guesses\nand it's game over.",
+		Controls: "A-Z: guess a letter",
+	},
+	7: {
+		Rules:    "Place X's on a 3x3 grid. Get three\nin a row to win. Block the AI's\nattempts to do the same.",
+		Controls: "Arrows: move | Enter: place mark",
+	},
+	8: {
+		Rules:    "Deduce the secret 4-color code.\nBlack peg = right color, right spot.\nWhite peg = right color, wrong spot.",
+		Controls: "1-6: pick color | Enter: submit guess",
+	},
+	9: {
+		Rules:    "Flip cards to find matching pairs.\nRemember positions to clear the\nboard in the fewest moves.",
+		Controls: "Arrows: move | Enter/Space: flip card",
+	},
+	10: {
+		Rules:    "Drop colored discs into columns.\nFirst to connect 4 in a row\n(horizontal, vertical, diagonal) wins.",
+		Controls: "Left/Right: choose column | Enter: drop",
+	},
+	11: {
+		Rules:    "Slide numbered tiles to arrange\nthem 1-15 in order. Use the empty\nspace to maneuver.",
+		Controls: "Arrow keys to slide adjacent tile",
+	},
+	12: {
+		Rules:    "Guide the snake to eat food and\ngrow longer. Don't crash into walls\nor your own tail.",
+		Controls: "Arrow keys: direction | P: pause",
+	},
+	13: {
+		Rules:    "Rotate and place falling blocks to\ncomplete rows. Completed rows are\ncleared for points.",
+		Controls: "Arrows: move | Up: rotate | Space: drop",
+	},
+	14: {
+		Rules:    "Move cards between tableau piles and\nfoundations. Build foundations up by\nsuit from Ace to King.",
+		Controls: "Arrows: move | Enter: select/place",
+	},
+	15: {
+		Rules:    "Type the displayed text as fast and\naccurately as you can. Your WPM\nand accuracy are measured.",
+		Controls: "Type the highlighted text",
+	},
+}
+
+// tips shown in the rotating ticker at the bottom of the menu.
+var tips = []string{
+	"Tip: Press P to pause in Snake and Tetris",
+	"Tip: In Wordle, green = correct position, yellow = wrong position",
+	"Tip: In Minesweeper, flag suspected mines with F",
+	"Tip: 2048 strategy -- keep your largest tile in a corner",
+	"Tip: Sudoku -- scan rows, columns, and boxes to eliminate candidates",
+	"Tip: In Blackjack, stand on 17+ against a dealer showing 2-6",
+	"Tip: Yahtzee -- go for the bonus by scoring 63+ in the upper section",
+	"Tip: Tic-Tac-Toe -- take the center square first",
+	"Tip: In Mastermind, use your first guesses to narrow down colors",
+	"Tip: Memory -- flip cards methodically, row by row",
+	"Tip: Connect Four -- control the center columns for more options",
+	"Tip: Typing Test -- focus on accuracy first, speed follows",
+	"Tip: In Hangman, guess vowels first to reveal the word structure",
+	"Tip: Press number keys 1-9 or 0/a-f to quick-select games",
+}
+
+// shortcutKeys maps the display position (0-based) within the flattened
+// category list to a shortcut label. Games 1-9 use "1"-"9", game 10
+// uses "0", games 11-16 use "a"-"f".
+func shortcutLabel(displayIndex int) string {
+	if displayIndex < 9 {
+		return string(rune('1' + displayIndex))
+	}
+	if displayIndex == 9 {
+		return "0"
+	}
+	return string(rune('a' + displayIndex - 10))
+}

--- a/internal/menu/model.go
+++ b/internal/menu/model.go
@@ -3,6 +3,7 @@ package menu
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -38,36 +39,160 @@ var Games = []GameChoice{
 // SettingsIndex is the menu index for the Settings entry.
 const SettingsIndex = 16
 
+// allChoices returns Games plus the Settings entry.
+var allChoices = append(Games, GameChoice{"Settings", "Preferences and configuration"})
+
+// menuRow represents a single row in the rendered menu. It is either a
+// category header (gameIndex == -1) or a selectable game/settings entry.
+type menuRow struct {
+	gameIndex    int // -1 for category header, 0-15 for games, SettingsIndex for settings
+	displayIndex int // sequential position among selectable items (for shortcut keys)
+}
+
+// buildRows constructs the flat list of menu rows from categories + settings.
+func buildRows() []menuRow {
+	rows := make([]menuRow, 0, len(Games)+len(categories)+2) // games + headers + settings
+	displayIdx := 0
+	for catIdx := range categories {
+		// Category header row.
+		rows = append(rows, menuRow{gameIndex: -(catIdx + 1), displayIndex: -1})
+		// Game rows in this category.
+		for _, gi := range categories[catIdx].Indices {
+			rows = append(rows, menuRow{gameIndex: gi, displayIndex: displayIdx})
+			displayIdx++
+		}
+	}
+	// Blank separator is handled in View, not as a row.
+	// Settings row.
+	rows = append(rows, menuRow{gameIndex: SettingsIndex, displayIndex: displayIdx})
+	return rows
+}
+
+var menuRows = buildRows()
+
+// isSelectable returns true if this row can be cursor-selected.
+func (r menuRow) isSelectable() bool {
+	return r.gameIndex >= 0
+}
+
+// isCategoryHeader returns true if this row is a section header.
+func (r menuRow) isCategoryHeader() bool {
+	return r.gameIndex < 0
+}
+
+// categoryIndex returns the index into the categories slice for a
+// header row. Returns -1 for non-header rows.
+func (r menuRow) categoryIndex() int {
+	if !r.isCategoryHeader() {
+		return -1
+	}
+	return -(r.gameIndex + 1)
+}
+
+// Tick messages.
+type (
+	tipTickMsg   struct{}
+	blinkTickMsg struct{}
+	timerTickMsg struct{}
+	animTickMsg  struct{}
+)
+
+const (
+	tipInterval   = 4 * time.Second
+	blinkInterval = 500 * time.Millisecond
+	timerInterval = 1 * time.Minute
+	animInterval  = 40 * time.Millisecond
+)
+
+func tipTick() tea.Cmd {
+	return tea.Tick(tipInterval, func(time.Time) tea.Msg { return tipTickMsg{} })
+}
+
+func blinkTick() tea.Cmd {
+	return tea.Tick(blinkInterval, func(time.Time) tea.Msg { return blinkTickMsg{} })
+}
+
+func timerTick() tea.Cmd {
+	return tea.Tick(timerInterval, func(time.Time) tea.Msg { return timerTickMsg{} })
+}
+
+func animTick() tea.Cmd {
+	return tea.Tick(animInterval, func(time.Time) tea.Msg { return animTickMsg{} })
+}
+
+// AnimCmd returns a tea.Cmd that starts the entrance animation tick.
+// The app model calls this when returning from a game.
+func AnimCmd() tea.Cmd {
+	return animTick()
+}
+
 // Model is the game selection menu.
 type Model struct {
 	choices  []GameChoice
-	cursor   int
+	cursor   int // index into menuRows (only lands on selectable rows)
 	width    int
 	height   int
 	selected int
 	quitting bool
 	scores   *scores.Store
-}
 
-// allChoices returns Games plus the Settings entry.
-var allChoices = append(Games, GameChoice{"Settings", "Preferences and configuration"})
+	// Tip ticker (#25).
+	tipIndex int
+
+	// Cursor blink (#28).
+	blinkOn bool
+
+	// Session stats (#26).
+	gamesPlayed  int
+	sessionStart time.Time
+	sessionMins  int
+
+	// Entrance animation (#27).
+	animStep    int  // -1 = no animation, 0..N = rows revealed so far
+	showWelcome bool // flash "Welcome back!" briefly
+}
 
 // New creates a menu model with optional score display.
 func New(s *scores.Store) Model {
 	return Model{
-		choices:  allChoices,
-		cursor:   0,
-		selected: -1,
-		scores:   s,
+		choices:      allChoices,
+		cursor:       firstSelectableRow(),
+		selected:     -1,
+		scores:       s,
+		blinkOn:      true,
+		sessionStart: time.Now(),
+		animStep:     -1,
 	}
 }
 
-// Init returns nil; no initial command needed.
-func (m Model) Init() tea.Cmd {
-	return nil
+// firstSelectableRow returns the index of the first selectable row.
+func firstSelectableRow() int {
+	for i := range menuRows {
+		if menuRows[i].isSelectable() {
+			return i
+		}
+	}
+	return 0
 }
 
-// Update handles key navigation.
+// Init starts background tickers.
+func (m Model) Init() tea.Cmd {
+	return tea.Batch(tipTick(), blinkTick(), timerTick())
+}
+
+// IncrementGamesPlayed bumps the session game counter. Called by the
+// app model when returning from a game.
+func (m *Model) IncrementGamesPlayed() {
+	m.gamesPlayed++
+}
+
+// TriggerEntrance starts the entrance animation (items appear one by one).
+func (m *Model) TriggerEntrance() {
+	m.animStep = 0
+	m.showWelcome = true
+}
+
+// Update handles key navigation, ticks, and quick-select.
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
@@ -75,95 +200,339 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.height = msg.Height
 		return m, nil
 
+	case tipTickMsg:
+		m.tipIndex = (m.tipIndex + 1) % len(tips)
+		return m, tipTick()
+
+	case blinkTickMsg:
+		m.blinkOn = !m.blinkOn
+		return m, blinkTick()
+
+	case timerTickMsg:
+		m.sessionMins = int(time.Since(m.sessionStart).Minutes())
+		return m, timerTick()
+
+	case animTickMsg:
+		if m.animStep >= 0 {
+			m.animStep++
+			totalRows := len(menuRows)
+			if m.animStep > totalRows+5 { // +5 for footer elements
+				m.animStep = -1
+				m.showWelcome = false
+			}
+			return m, animTick()
+		}
+		return m, nil
+
 	case tea.KeyMsg:
+		// During entrance animation, any key finishes it instantly.
+		if m.animStep >= 0 {
+			m.animStep = -1
+			m.showWelcome = false
+			return m, nil
+		}
+
 		switch msg.String() {
 		case "up", "k":
-			m.cursor--
-			if m.cursor < 0 {
-				m.cursor = len(m.choices) - 1
-			}
+			m.cursor = m.prevSelectable(m.cursor)
 		case "down", "j":
-			m.cursor++
-			if m.cursor >= len(m.choices) {
-				m.cursor = 0
-			}
+			m.cursor = m.nextSelectable(m.cursor)
 		case "enter":
-			m.selected = m.cursor
+			m.selected = menuRows[m.cursor].gameIndex
 		case "q", "esc":
 			m.quitting = true
+		default:
+			// Number key quick-select (#23).
+			if idx, ok := m.shortcutToGameIndex(msg.String()); ok {
+				m.selected = idx
+			}
 		}
 	}
 
 	return m, nil
 }
 
+// nextSelectable finds the next selectable row after current, wrapping.
+func (m Model) nextSelectable(current int) int {
+	n := len(menuRows)
+	for i := 1; i < n; i++ {
+		idx := (current + i) % n
+		if menuRows[idx].isSelectable() {
+			return idx
+		}
+	}
+	return current
+}
+
+// prevSelectable finds the previous selectable row before current, wrapping.
+func (m Model) prevSelectable(current int) int {
+	n := len(menuRows)
+	for i := 1; i < n; i++ {
+		idx := (current - i + n) % n
+		if menuRows[idx].isSelectable() {
+			return idx
+		}
+	}
+	return current
+}
+
+// shortcutToGameIndex maps a key press to a game index.
+// 1-9 -> display positions 0-8, 0 -> position 9, a-f -> positions 10-15.
+// Returns the original Games index and true if valid.
+func (m Model) shortcutToGameIndex(key string) (int, bool) {
+	displayIdx := -1
+	if len(key) == 1 {
+		ch := key[0]
+		switch {
+		case ch >= '1' && ch <= '9':
+			displayIdx = int(ch - '1')
+		case ch == '0':
+			displayIdx = 9
+		case ch >= 'a' && ch <= 'f':
+			displayIdx = int(ch-'a') + 10
+		}
+	}
+	if displayIdx < 0 {
+		return -1, false
+	}
+	// Find the row with this display index.
+	for i := range menuRows {
+		if menuRows[i].displayIndex == displayIdx && menuRows[i].gameIndex >= 0 && menuRows[i].gameIndex < SettingsIndex {
+			return menuRows[i].gameIndex, true
+		}
+	}
+	return -1, false
+}
+
 // Styles.
 var (
 	titleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#DCFFDC"))
+			Foreground(lipgloss.Color("#00FF87"))
+
+	categoryStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("243")).
+			Italic(true)
 
 	cursorStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#FFD700"))
 
 	nameStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("15"))
+			Foreground(lipgloss.Color("#FFFFFF"))
 
 	nameSelectedStyle = lipgloss.NewStyle().
 				Bold(true).
 				Foreground(lipgloss.Color("#FFD700"))
 
 	descStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("242"))
+			Foreground(lipgloss.Color("243"))
 
 	footerStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("240"))
 
+	tipStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240")).
+			Italic(true)
+
 	highScoreStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#FFD700"))
+
+	statsStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("243"))
+
+	previewBorder = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("240")).
+			Foreground(lipgloss.Color("250")).
+			Padding(0, 1).
+			Width(42)
+
+	previewTitleStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("#FFFFFF"))
+
+	previewDimStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("243"))
+
+	panelBorder = lipgloss.RoundedBorder()
+
+	shortcutStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("243"))
+
+	iconStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("250"))
+
+	welcomeStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#00FF87"))
 )
 
-// View renders the menu.
+// asciiTitle is a styled "CLI PLAY" header.
+var asciiTitle = strings.Join([]string{
+	"  ___  _     ___   ___  _       _   __   __",
+	" / __|| |   |_ _| | _ \\| |     /_\\ \\ \\ / /",
+	"| (__ | |__  | |  |  _/| |__  / _ \\ \\ V / ",
+	" \\___||____||___| |_|  |____|/_/ \\_\\ |_|  ",
+}, "\n")
+
+// View renders the menu with categories, icons, preview, stats, and tips.
 func (m Model) View() string {
 	var b strings.Builder
 
-	b.WriteString(titleStyle.Render("CLI Play"))
+	// Title (#22).
+	b.WriteString(titleStyle.Render(asciiTitle))
 	b.WriteString("\n\n")
 
-	for i, choice := range m.choices {
+	// Session stats bar (#26).
+	elapsed := m.sessionMins
+	if elapsed == 0 && time.Since(m.sessionStart) >= 30*time.Second {
+		elapsed = 1
+	}
+	statsLine := fmt.Sprintf("Games played: %d | Session: %dm", m.gamesPlayed, elapsed)
+	b.WriteString(statsStyle.Render(statsLine))
+	b.WriteString("\n\n")
+
+	// Welcome back flash (#27).
+	if m.showWelcome {
+		b.WriteString(welcomeStyle.Render("  Welcome back!"))
+		b.WriteString("\n\n")
+	}
+
+	// Game list with categories (#30), icons (#24), shortcuts (#23).
+	for rowIdx, row := range menuRows {
+		// Entrance animation: skip rows not yet revealed.
+		if m.animStep >= 0 && rowIdx > m.animStep {
+			break
+		}
+
+		if row.isCategoryHeader() {
+			catIdx := row.categoryIndex()
+			if catIdx >= 0 && catIdx < len(categories) {
+				cat := categories[catIdx]
+				if rowIdx > 0 {
+					b.WriteString("\n")
+				}
+				b.WriteString(categoryStyle.Render(fmt.Sprintf("  %s %s", cat.Icon, cat.Name)))
+				b.WriteString("\n")
+			}
+			continue
+		}
+
 		// Separator before Settings.
-		if i == SettingsIndex {
+		if row.gameIndex == SettingsIndex {
 			b.WriteString("\n")
 		}
 
-		indicator := "  "
+		// Cursor indicator (#28, #22).
+		indicator := "   "
 		ns := nameStyle
-		if i == m.cursor {
-			indicator = "> "
+		if rowIdx == m.cursor {
+			if m.blinkOn {
+				indicator = " \u25b6 " // filled triangle
+			} else {
+				indicator = " \u25b7 " // outline triangle
+			}
 			ns = nameSelectedStyle
 		}
 
 		b.WriteString(cursorStyle.Render(indicator))
-		b.WriteString(ns.Render(choice.Name))
-		b.WriteString("  ")
-		b.WriteString(descStyle.Render(choice.Description))
 
-		if hs := m.highScoreLabel(i); hs != "" {
+		// Shortcut key (#23).
+		if row.gameIndex < SettingsIndex && row.displayIndex >= 0 {
+			label := shortcutLabel(row.displayIndex)
+			b.WriteString(shortcutStyle.Render(fmt.Sprintf("[%s] ", label)))
+		} else {
+			b.WriteString("    ") // align settings with games
+		}
+
+		// Icon (#24).
+		if icon, ok := gameIcon[row.gameIndex]; ok {
+			b.WriteString(iconStyle.Render(fmt.Sprintf("%-3s", icon)))
+		} else if row.gameIndex == SettingsIndex {
+			b.WriteString(iconStyle.Render("\u2699  ")) // gear for settings
+		}
+
+		// Game name and description.
+		name := ""
+		desc := ""
+		if row.gameIndex == SettingsIndex {
+			name = "Settings"
+			desc = "Preferences and configuration"
+		} else if row.gameIndex >= 0 && row.gameIndex < len(Games) {
+			name = Games[row.gameIndex].Name
+			desc = Games[row.gameIndex].Description
+		}
+
+		b.WriteString(ns.Render(fmt.Sprintf("%-16s", name)))
+		b.WriteString(descStyle.Render(desc))
+
+		// High score.
+		if hs := m.highScoreLabel(row.gameIndex); hs != "" {
 			b.WriteString("  ")
 			b.WriteString(highScoreStyle.Render(hs))
 		}
 		b.WriteString("\n")
 	}
 
-	b.WriteString("\n")
-	b.WriteString(footerStyle.Render("  ↑↓ Navigate | Enter Select | Q Quit"))
+	// Preview panel (#29).
+	preview := m.renderPreview()
+	if preview != "" {
+		b.WriteString("\n")
+		b.WriteString(preview)
+	}
 
-	content := lipgloss.NewStyle().
-		Align(lipgloss.Center).
+	b.WriteString("\n")
+
+	// Tip ticker (#25).
+	if m.tipIndex < len(tips) {
+		b.WriteString(tipStyle.Render(tips[m.tipIndex]))
+		b.WriteString("\n")
+	}
+
+	// Footer.
+	b.WriteString(footerStyle.Render("  \u2191\u2193 Navigate | Enter Select | 1-9/0/a-f Quick Select | Q Quit"))
+
+	// Wrap in bordered panel (#21).
+	panel := lipgloss.NewStyle().
+		Border(panelBorder).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(1, 2).
+		BorderTop(true).
+		BorderBottom(true).
+		BorderLeft(true).
+		BorderRight(true).
 		Render(b.String())
 
-	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, panel)
+}
+
+// renderPreview returns the preview panel for the currently highlighted game.
+func (m Model) renderPreview() string {
+	gameIdx := -1
+	if m.cursor >= 0 && m.cursor < len(menuRows) {
+		row := menuRows[m.cursor]
+		if row.gameIndex >= 0 && row.gameIndex < len(Games) {
+			gameIdx = row.gameIndex
+		}
+	}
+	if gameIdx < 0 {
+		return ""
+	}
+
+	p, ok := previews[gameIdx]
+	if !ok {
+		return ""
+	}
+
+	var pb strings.Builder
+	pb.WriteString(previewTitleStyle.Render(Games[gameIdx].Name))
+	pb.WriteString("\n")
+	pb.WriteString(previewDimStyle.Render(p.Rules))
+	pb.WriteString("\n\n")
+	pb.WriteString(previewDimStyle.Render("Controls: " + p.Controls))
+
+	return previewBorder.Render(pb.String())
 }
 
 // MenuText returns the menu layout as plain text (no ANSI styling).
@@ -172,18 +541,29 @@ func (m Model) View() string {
 func MenuText(width, height int) string {
 	var b strings.Builder
 
-	b.WriteString("CLI Play")
+	b.WriteString(asciiTitle)
 	b.WriteString("\n\n")
 
-	for i, choice := range allChoices {
-		if i == SettingsIndex {
+	displayIdx := 0
+	for catIdx := range categories {
+		cat := categories[catIdx]
+		if catIdx > 0 {
 			b.WriteString("\n")
 		}
-		b.WriteString(fmt.Sprintf("  %s  %s\n", choice.Name, choice.Description))
+		b.WriteString(fmt.Sprintf("  %s %s\n", cat.Icon, cat.Name))
+		for _, gi := range cat.Indices {
+			label := shortcutLabel(displayIdx)
+			icon := gameIcon[gi]
+			b.WriteString(fmt.Sprintf("   [%s] %-3s%-16s%s\n", label, icon, Games[gi].Name, Games[gi].Description))
+			displayIdx++
+		}
 	}
 
 	b.WriteString("\n")
-	b.WriteString("  ↑↓ Navigate | Enter Select | Q Quit")
+	b.WriteString(fmt.Sprintf("       \u2699  %-16s%s\n", "Settings", "Preferences and configuration"))
+
+	b.WriteString("\n")
+	b.WriteString("  \u2191\u2193 Navigate | Enter Select | 1-9/0/a-f Quick Select | Q Quit")
 
 	return b.String()
 }


### PR DESCRIPTION
## Summary

- Bordered panel (#21), ASCII art title with refined colors (#22)
- Number key quick-select: 1-9, 0, a-f for all 16 games (#23)
- Unicode mini-icons per game (#24)
- Scrolling tip ticker with 4s rotation (#25)
- Session stats bar showing games played and session duration (#26)
- Entrance animation when returning from a game (#27)
- Animated cursor with 500ms blink (#28)
- Game preview panel with rules and controls for highlighted game (#29)
- Category grouping: Classic, Puzzles, Action, Strategy, Skills (#30)

Closes #21, Closes #22, Closes #23, Closes #24, Closes #25
Closes #26, Closes #27, Closes #28, Closes #29, Closes #30

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `gofmt` applied to all changed files
- [ ] CI lint passes
- [ ] Manual: run app, verify category grouping, icons, shortcuts, preview panel
- [ ] Manual: verify entrance animation on game exit, cursor blink, tip rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)