### PR TITLE
fix: responsive menu layout with multi-column support

### DIFF
--- a/internal/menu/model.go
+++ b/internal/menu/model.go
@@ -75,20 +75,6 @@ func (r menuRow) isSelectable() bool {
 	return r.gameIndex >= 0
 }
 
-// isCategoryHeader returns true if this row is a section header.
-func (r menuRow) isCategoryHeader() bool {
-	return r.gameIndex < 0
-}
-
-// categoryIndex returns the index into the categories slice for a
-// header row. Returns -1 for non-header rows.
-func (r menuRow) categoryIndex() int {
-	if !r.isCategoryHeader() {
-		return -1
-	}
-	return -(r.gameIndex + 1)
-}
-
 // Tick messages.
 type (
 	tipTickMsg   struct{}


### PR DESCRIPTION
## Summary

- Menu progressively hides elements (preview, title, stats, tips) when terminal is too short
- Renders games in 2-3 columns when terminal is wide enough, dropping descriptions in compact mode
- Added left/right arrow navigation; up/down skip by column count for natural grid movement

## Test plan

- [ ] Run in narrow terminal (~30 lines) -- verify no overflow, preview hidden
- [ ] Run in wide terminal (~120 cols) -- verify 2-3 column layout
- [ ] Verify arrow key navigation works naturally in grid layout
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)