### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+# EditorConfig helps maintain consistent coding styles
+# https://editorconfig.org
+
+root = false


### PR DESCRIPTION
## Summary
- Adds minimal `.editorconfig` with `root = false` to inherit formatting rules from the parent `D:\DevSpace\.editorconfig`

## Test plan
- [x] Single file, no logic changes — docs-only exception applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)