### PR TITLE
fix: compact menu layout, transition animation, and game UI fixes

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -100,7 +100,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.active == screenSplash {
 			// Build the text that the transition will dissolve and reveal.
 			splashText := splash.TitleArt + "\n\n" + splash.Credits
-			menuText := menu.MenuText(m.width, m.height)
+			menuText := m.menu.TransitionText()
 			m.transition = transition.New(m.width, m.height, splashText, menuText)
 			m.active = screenTransition
 			return m, m.transition.Init()
@@ -119,7 +119,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.transition, cmd = m.transition.Update(msg)
 		if m.transition.Done() {
 			m.active = screenMenu
-			return m, m.menu.Init()
+			return m, tea.Batch(tea.ClearScreen, m.menu.Init())
 		}
 		return m, cmd
 

--- a/internal/blackjack/model.go
+++ b/internal/blackjack/model.go
@@ -120,6 +120,8 @@ func (m Model) updatePlayerTurn(key string) (tea.Model, tea.Cmd) {
 		if m.game.CanDoubleDown() {
 			m.game.DoubleDown() //nolint:errcheck // CanDoubleDown pre-validates
 		}
+	case "q":
+		m.done = true
 	}
 	return m, nil
 }
@@ -269,6 +271,7 @@ func (m Model) renderHelp() string {
 		if m.game.CanDoubleDown() {
 			help += "  [D] Double Down"
 		}
+		help += "  [Q] Quit"
 		return helpStyle.Render(help)
 	case PhaseResult:
 		return helpStyle.Render("[Enter/N] New Round  [Q] Quit")

--- a/internal/menu/data.go
+++ b/internal/menu/data.go
@@ -33,7 +33,7 @@ var categories = []category{
 	{Name: "Puzzles", Icon: "\U0001f9e9", Indices: []int{2, 3, 4, 5, 11, 8}}, // Wordle, Minesweeper, Sudoku, 2048, Fifteen Puzzle, Mastermind
 	{Name: "Action", Icon: "\U0001f3ae", Indices: []int{12, 13}},             // Snake, Tetris
 	{Name: "Strategy", Icon: "\U0001f0cf", Indices: []int{6, 7, 10, 9}},      // Hangman, Tic-Tac-Toe, Connect Four, Memory
-	{Name: "Skills", Icon: "\u2328\ufe0f", Indices: []int{15}},               // Typing Test
+	{Name: "Skills", Icon: "\U0001f3af", Indices: []int{15}}, // Typing Test (dart/target -- consistent 2-cell emoji)
 }
 
 // gamePreview holds the info panel text for each game.

--- a/internal/tictactoe/model.go
+++ b/internal/tictactoe/model.go
@@ -212,7 +212,7 @@ func (m Model) renderBoard() string {
 		rows = append(rows, strings.Join(cells, gridStyle.Render(" │ ")))
 
 		if r < 2 {
-			rows = append(rows, gridStyle.Render("───┼───┼───"))
+			rows = append(rows, gridStyle.Render("─── ┼ ─── ┼ ───"))
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Compact menu to fit VS Code integrated terminal: single-line title, tighter vertical spacing, reduced padding
- Fix transition animation leaving artifacts by creating dedicated `TransitionText()` method and stripping emoji that caused width mismatches in the grid renderer
- Add `tea.ClearScreen` on transition-to-menu switch to wipe stray characters
- Fix Skills category icon (variation selector emoji `⌨️` → `🎯`) that caused a stray border bar
- Add Q quit to Blackjack player turn phase (was missing from that game state)
- Fix tic-tac-toe grid separator width to align with cell row width

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] Transition animation renders cleanly without artifacts (verified twice)
- [x] Menu fits in VS Code terminal without scrolling
- [x] Tic-tac-toe grid lines align with cells
- [x] Blackjack Q quit works during player turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)