### PR TITLE
fix: add .gitattributes to enforce LF for Go files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Normalize line endings for all text files
+* text=auto
+
+# Force LF for Go source files (gofmt requires LF)
+*.go text eol=lf
+
+# Force LF for shell scripts
+*.sh text eol=lf
+
+# Force LF for Makefiles
+Makefile text eol=lf
+
+# Force CRLF for Windows-specific files
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` to enforce LF line endings for `*.go` and `*.sh` files
- Fixes golangci-lint gofmt violations caused by Windows CRLF line endings on checkout
- Pre-push hook now passes cleanly (was blocking branch deletions)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Pre-push hook passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)