### PR TITLE
feat: add GitHub Copilot integration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,56 @@
+# cli-play -- Copilot Instructions
+
+Interactive CLI playground showcasing terminal UI patterns with Bubbletea and Lipgloss.
+
+## Tech Stack
+
+- **Go** 1.25 -- primary language
+- **Bubbletea** -- TUI framework (Elm architecture for terminals)
+- **Lipgloss** -- terminal styling (colors, borders, layout)
+- **Bubbles** -- reusable TUI components (spinners, text inputs, viewports)
+
+## Project Structure
+
+```text
+cli-play/
+├── cmd/              - Entry points and CLI wiring
+├── internal/         - Private application packages
+├── scripts/          - Build and utility scripts
+├── .github/          - CI workflows and Copilot config
+└── CLAUDE.md         - Claude Code instructions
+```
+
+## Code Style
+
+- Conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
+- Co-author tag: `Co-Authored-By: GitHub Copilot <noreply@github.com>`
+- Errors wrapped with context: `fmt.Errorf("operation: %w", err)`
+- Table-driven tests with `t.Run` and descriptive names
+- All lint checks must pass before committing (golangci-lint v2)
+
+## Coding Guidelines
+
+- Fix errors immediately -- never classify them as pre-existing
+- Build, test, and lint must pass before any commit
+- Never skip hooks (`--no-verify`) or force-push main
+- Remove unused code completely; no backwards-compatibility hacks
+
+## Available Resources
+
+```bash
+make build        # Compile the project
+make test         # Run all tests
+make lint         # Run golangci-lint
+make run          # Run the application
+go build ./...    # Direct build verification
+go test ./...     # Direct test run
+```
+
+## Do NOT
+
+- Add `//nolint` directives without fixing the root cause first
+- Commit generated files without regenerating them first
+- Add dependencies without updating the lock file
+- Use `panic` in library code; return errors instead
+- Store secrets, tokens, or credentials in code or config files
+- Mark work as complete when known errors remain

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,121 @@
+---
+applyTo: "**/*.go"
+---
+
+# Go Coding Instructions
+
+## Error Handling
+
+Always wrap errors with context using `fmt.Errorf`:
+
+```go
+// GOOD: wraps error with context
+if err != nil {
+    return fmt.Errorf("fetch device %s: %w", id, err)
+}
+
+// BAD: discards context
+if err != nil {
+    return err
+}
+```
+
+Never return `(result, nil)` when `err != nil`. Propagate both:
+
+```go
+// GOOD: nilerr compliant
+return &Result{Message: runErr.Error()}, fmt.Errorf("run: %w", runErr)
+```
+
+## Named Returns
+
+When golangci-lint flags `unnamedResult`, add named returns. After adding names,
+change `:=` to `=` for those variables and remove redundant `var` declarations:
+
+```go
+// GOOD: named returns, = not :=
+func compute(data []float64) (score float64, detail string) {
+    switch {
+    case len(data) == 0:
+        detail = "no data"
+    default:
+        score = average(data)
+        detail = fmt.Sprintf("n=%d", len(data))
+    }
+    return score, detail
+}
+```
+
+## Lint Patterns (golangci-lint v2)
+
+Fix these before committing:
+
+- **rangeValCopy**: `for _, v := range slice` on structs >64 bytes -- use `for i := range slice { slice[i]... }`
+- **prealloc**: `var result []T` in a loop -- use `make([]T, 0, len(source))`
+- **appendCombine**: two consecutive `append()` to same slice -- combine into one call
+- **emptyStringTest**: `len(s) > 0` -- use `s != ""`
+- **httpNoBody**: `http.NewRequestWithContext(ctx, method, url, nil)` -- use `http.NoBody`
+- **bodyclose**: always close `resp.Body`, including deferred: `defer func() { _ = resp.Body.Close() }()`
+- **exhaustive**: switch on enum types must list ALL cases explicitly
+- **noctx**: use `ExecContext`, `QueryContext`, `QueryRowContext` instead of context-less variants
+- **paramTypeCombine**: `(a int, b int)` -- combine consecutive same-type params to `(a, b int)`
+- **builtinShadow**: don't use `new`, `make`, `len`, `cap`, `close`, `delete`, `copy`, `append`, `min`, `max`, `clear` as parameter names
+- **gosec G101**: constants named like credentials (containing "password", "token", "secret") need `//nolint:gosec // G101: <reason>`
+- **preferFprint**: `b.WriteString(fmt.Sprintf(...))` -- use `fmt.Fprintf(&b, ...)` instead
+- **dupBranchBody**: identical `if`/`else` branches -- remove the conditional, keep just the body
+- **sloppyReassign**: `if err = f(); err != nil` with named return `err` -- use `:=` to shadow instead
+
+## Testing
+
+Use table-driven tests with `t.Run`:
+
+```go
+func TestSomething(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    int
+        wantErr bool
+    }{
+        {name: "valid input", input: "abc", want: 3},
+        {name: "empty input", input: "", wantErr: true},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := Something(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+            }
+            if got != tt.want {
+                t.Errorf("got %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## HTTP Handlers (Go 1.22+)
+
+Use Go 1.22 enhanced `ServeMux` patterns:
+
+```go
+mux.HandleFunc("GET /items/{id}", h.getItem)
+mux.HandleFunc("POST /items", h.createItem)
+```
+
+Always name `*http.Request` parameter even if unused -- expanding stubs later requires it.
+
+## Imports
+
+Group imports in three blocks separated by blank lines:
+
+```go
+import (
+    "context"
+    "fmt"
+
+    "github.com/external/pkg"
+
+    "github.com/yourorg/project/internal/models"
+)
+```

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -50,20 +50,31 @@ func compute(data []float64) (score float64, detail string) {
 
 Fix these before committing:
 
-- **rangeValCopy**: `for _, v := range slice` on structs >64 bytes -- use `for i := range slice { slice[i]... }`
-- **prealloc**: `var result []T` in a loop -- use `make([]T, 0, len(source))`
-- **appendCombine**: two consecutive `append()` to same slice -- combine into one call
-- **emptyStringTest**: `len(s) > 0` -- use `s != ""`
-- **httpNoBody**: `http.NewRequestWithContext(ctx, method, url, nil)` -- use `http.NoBody`
-- **bodyclose**: always close `resp.Body`, including deferred: `defer func() { _ = resp.Body.Close() }()`
-- **exhaustive**: switch on enum types must list ALL cases explicitly
-- **noctx**: use `ExecContext`, `QueryContext`, `QueryRowContext` instead of context-less variants
-- **paramTypeCombine**: `(a int, b int)` -- combine consecutive same-type params to `(a, b int)`
-- **builtinShadow**: don't use `new`, `make`, `len`, `cap`, `close`, `delete`, `copy`, `append`, `min`, `max`, `clear` as parameter names
-- **gosec G101**: constants named like credentials (containing "password", "token", "secret") need `//nolint:gosec // G101: <reason>`
-- **preferFprint**: `b.WriteString(fmt.Sprintf(...))` -- use `fmt.Fprintf(&b, ...)` instead
-- **dupBranchBody**: identical `if`/`else` branches -- remove the conditional, keep just the body
-- **sloppyReassign**: `if err = f(); err != nil` with named return `err` -- use `:=` to shadow instead
+- **rangeValCopy**: `for _, v := range slice` on large structs.
+  Use `for i := range slice { slice[i]... }`
+- **prealloc**: `var result []T` in a loop.
+  Use `make([]T, 0, len(source))`
+- **appendCombine**: two consecutive `append()` to same slice.
+  Combine into one call
+- **emptyStringTest**: `len(s) > 0`. Use `s != ""`
+- **httpNoBody**: use `http.NoBody` instead of `nil` body
+- **bodyclose**: always close `resp.Body`. Deferred:
+  `defer func() { _ = resp.Body.Close() }()`
+- **exhaustive**: switch on enum types must list ALL cases
+- **noctx**: use `ExecContext`, `QueryContext`,
+  `QueryRowContext` instead of context-less variants
+- **paramTypeCombine**: `(a int, b int)` becomes `(a, b int)`
+- **builtinShadow**: don't shadow `new`, `make`, `len`,
+  `cap`, `close`, `delete`, `copy`, `append`, `min`, `max`,
+  `clear` as parameter names
+- **gosec G101**: credential-adjacent constants need
+  `//nolint:gosec // G101: <reason>`
+- **preferFprint**: use `fmt.Fprintf(&b, ...)` instead of
+  `b.WriteString(fmt.Sprintf(...))`
+- **dupBranchBody**: identical `if`/`else` branches.
+  Remove the conditional, keep just the body
+- **sloppyReassign**: `if err = f(); err != nil` with named
+  return `err`. Use `:=` to shadow instead
 
 ## Testing
 
@@ -103,7 +114,8 @@ mux.HandleFunc("GET /items/{id}", h.getItem)
 mux.HandleFunc("POST /items", h.createItem)
 ```
 
-Always name `*http.Request` parameter even if unused -- expanding stubs later requires it.
+Always name `*http.Request` parameter even if unused.
+Expanding stubs later requires it.
 
 ## Imports
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,23 @@
+name: Copilot Setup Steps
+
+on: workflow_dispatch
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
+
+      - name: Verify build
+        run: go build ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,8 @@ cli-play/
 
 These are unconditional -- no optimization or time pressure overrides them:
 
-1. **Quality**: Once found, always fix, never leave. There is no "pre-existing" error.
+1. **Quality**: Once found, always fix, never leave.
+   There is no "pre-existing" error.
 2. **Verification**: Build, test, and lint must pass before any commit.
 3. **Safety**: Never force-push `main`. Never skip hooks. Never commit secrets.
 4. **Honesty**: Never mark work as complete when it is not.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,149 @@
+<!--
+  Scope: AGENTS.md guides the Copilot coding agent and Copilot Chat.
+  For code completion and code review patterns, see .github/copilot-instructions.md
+  and .github/instructions/*.instructions.md
+  For Claude Code, see CLAUDE.md
+-->
+
+# cli-play
+
+Interactive CLI playground showcasing terminal UI patterns with Bubbletea and Lipgloss.
+
+## Tech Stack
+
+- **Go** 1.25 -- primary language
+- **Bubbletea** -- TUI framework (Elm architecture for terminals)
+- **Lipgloss** -- terminal styling (colors, borders, layout)
+- **Bubbles** -- reusable TUI components (spinners, text inputs, viewports)
+
+## Build and Test Commands
+
+```bash
+# Build
+make build          # or: go build ./...
+
+# Test
+make test           # or: go test ./...
+
+# Lint
+make lint           # or: golangci-lint run ./...
+
+# Run
+make run            # or: go run ./cmd/cli-play
+
+# Full verification (run before any PR)
+make build && make test && make lint
+```
+
+## Project Structure
+
+```text
+cli-play/
+├── cmd/              - Entry points and CLI wiring
+├── internal/         - Private application packages
+├── scripts/          - Build and utility scripts
+├── .github/          - CI workflows and Copilot config
+├── Makefile          - Build targets
+├── CLAUDE.md         - Claude Code instructions
+└── AGENTS.md         - Copilot coding agent instructions
+```
+
+## Workflow Rules
+
+### Always Do
+
+- Create a feature branch for every change (`feature/issue-NNN-description`)
+- Use conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
+- Run build, test, and lint before opening a PR
+- Write table-driven tests with descriptive names
+- Wrap errors with context: `fmt.Errorf("operation: %w", err)`
+- Fix every error you find, regardless of who introduced it
+
+### Ask First
+
+- Adding new dependencies (check if stdlib covers the need)
+- Architectural changes (new packages, major interface changes)
+- Changes to CI/CD workflows
+- Removing or renaming public APIs
+
+### Never Do
+
+- Commit directly to `main` -- always use feature branches
+- Skip tests or lint checks -- even for "small changes"
+- Use `--no-verify` or `--force` flags
+- Commit secrets, credentials, or API keys
+- Add TODO comments without a linked issue number
+- Mark work as complete when build, test, or lint failures remain
+
+## Core Principles
+
+These are unconditional -- no optimization or time pressure overrides them:
+
+1. **Quality**: Once found, always fix, never leave. There is no "pre-existing" error.
+2. **Verification**: Build, test, and lint must pass before any commit.
+3. **Safety**: Never force-push `main`. Never skip hooks. Never commit secrets.
+4. **Honesty**: Never mark work as complete when it is not.
+
+## Error Handling
+
+```go
+// Wrap errors with context -- every return site should add meaning
+if err != nil {
+    return fmt.Errorf("load config: %w", err)
+}
+
+// Use sentinel errors for caller-distinguishable conditions
+var ErrNotFound = errors.New("not found")
+if errors.Is(err, ErrNotFound) { ... }
+```
+
+## Testing Conventions
+
+```go
+// Table-driven tests with descriptive names
+func TestFunctionName(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    string
+        wantErr bool
+    }{
+        {
+            name:  "valid input returns expected output",
+            input: "example",
+            want:  "result",
+        },
+        {
+            name:    "empty input returns error",
+            input:   "",
+            wantErr: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := FunctionName(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("FunctionName() error = %v, wantErr %v", err, tt.wantErr)
+            }
+            if got != tt.want {
+                t.Errorf("FunctionName() = %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## Commit Format
+
+```text
+feat: add user authentication endpoint
+
+Implements JWT-based login and token refresh. Tokens expire after 1h.
+
+Closes #42
+Co-Authored-By: GitHub Copilot <copilot@github.com>
+```
+
+Types: `feat` (new feature), `fix` (bug fix), `refactor` (no behavior change),
+`docs` (documentation only), `test` (tests only), `chore` (build/tooling).


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with three-tier boundaries for Copilot coding agent
- Add `.github/copilot-instructions.md` with project context
- Add `.github/workflows/copilot-setup-steps.yml` for Go dependency setup
- Add `.github/instructions/go.instructions.md` for Go-specific inline patterns

## Test plan

- [ ] Verify Copilot inline completions respect go.instructions.md
- [ ] Assign Copilot to a simple issue and verify setup-steps runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)